### PR TITLE
Agregar personajes base y demo LibGDX

### DIFF
--- a/core/src/main/java/com/juegDiego/game/JavaGame.java
+++ b/core/src/main/java/com/juegDiego/game/JavaGame.java
@@ -1,11 +1,9 @@
 package com.juegDiego.game;
 
-import com.badlogic.gdx.Game;
+import com.juegodiego.JuegoDiegoGame;
 
-public class JavaGame extends Game {
-    @Override
-    public void create() {
-        setScreen(new GameScreen(this));
-    }
+/**
+ * Clase puente para el lanzador existente.
+ */
+public class JavaGame extends JuegoDiegoGame {
 }
-

--- a/core/src/main/java/com/juegodiego/Const.java
+++ b/core/src/main/java/com/juegodiego/Const.java
@@ -1,0 +1,12 @@
+package com.juegodiego;
+
+/**
+ * Constantes del juego.
+ */
+public class Const {
+    public static final float VIEWPORT_WIDTH = 1280f;
+    public static final float VIEWPORT_HEIGHT = 720f;
+    public static final float GRAVITY = -980f;
+    public static final float MAX_FALL_SPEED = -1000f;
+    private Const() {}
+}

--- a/core/src/main/java/com/juegodiego/JuegoDiegoGame.java
+++ b/core/src/main/java/com/juegodiego/JuegoDiegoGame.java
@@ -1,0 +1,14 @@
+package com.juegodiego;
+
+import com.badlogic.gdx.Game;
+import com.juegodiego.screens.DemoScreen;
+
+/**
+ * Juego principal.
+ */
+public class JuegoDiegoGame extends Game {
+    @Override
+    public void create() {
+        setScreen(new DemoScreen(this));
+    }
+}

--- a/core/src/main/java/com/juegodiego/personajes/Orion.java
+++ b/core/src/main/java/com/juegodiego/personajes/Orion.java
@@ -1,0 +1,62 @@
+package com.juegodiego.personajes;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Input;
+import com.badlogic.gdx.assets.AssetManager;
+import com.badlogic.gdx.math.Vector2;
+
+/**
+ * Orion, personaje ágil con dash.
+ */
+public class Orion extends Personaje {
+    private boolean dashing;
+    private float dashTimer;
+
+    public Orion(AssetManager manager, Vector2 spawn) {
+        super("orion", "Orion", manager, spawn);
+        speed = 260f;
+        jumpForce = 520f;
+        attackPower = 10;
+        maxHP = hp = 100;
+    }
+
+    @Override
+    protected void handleInput(float delta) {
+        if (!dashing) {
+            boolean left = Gdx.input.isKeyPressed(Input.Keys.A) || Gdx.input.isKeyPressed(Input.Keys.LEFT);
+            boolean right = Gdx.input.isKeyPressed(Input.Keys.D) || Gdx.input.isKeyPressed(Input.Keys.RIGHT);
+            if (left && !right) moveLeft();
+            else if (right && !left) moveRight();
+            else stop();
+        }
+        if (Gdx.input.isKeyJustPressed(Input.Keys.SPACE)) jump();
+        if (Gdx.input.isKeyJustPressed(Input.Keys.J)) attack();
+        if (Gdx.input.isKeyJustPressed(Input.Keys.K)) dash();
+    }
+
+    private void dash() {
+        if (!cooldownReady("dash")) {
+            Gdx.app.log(nombre, "Dash CD: " + cooldowns.get("dash"));
+            return;
+        }
+        setCooldown("dash", 2.5f);
+        dashing = true;
+        dashTimer = 0.2f;
+        invulnerable = true;
+        velocity.x = dir == Direccion.RIGHT ? speed * 3f : -speed * 3f;
+        Gdx.app.log(nombre, "Dash!");
+    }
+
+    @Override
+    public void update(float delta) {
+        super.update(delta);
+        if (dashing) {
+            dashTimer -= delta;
+            if (dashTimer <= 0) {
+                dashing = false;
+                invulnerable = false;
+                stop();
+            }
+        }
+    }
+}

--- a/core/src/main/java/com/juegodiego/personajes/Personaje.java
+++ b/core/src/main/java/com/juegodiego/personajes/Personaje.java
@@ -1,0 +1,216 @@
+package com.juegodiego.personajes;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.assets.AssetManager;
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.Animation;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.graphics.g2d.TextureRegion;
+import com.badlogic.gdx.math.Vector2;
+import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.utils.ObjectMap;
+import com.juegodiego.Const;
+
+/**
+ * Clase base de personajes.
+ */
+public abstract class Personaje {
+    public enum Estado {IDLE, RUN, JUMP, FALL, ATTACK, HURT, DEAD}
+    public enum Direccion {LEFT, RIGHT}
+
+    protected final String id;
+    protected final String nombre;
+    protected final Vector2 position = new Vector2();
+    protected final Vector2 velocity = new Vector2();
+    protected float speed;
+    protected float jumpForce;
+    protected int maxHP;
+    protected int hp;
+    protected int attackPower;
+    protected boolean onGround;
+    protected Direccion dir = Direccion.RIGHT;
+    protected Estado estado = Estado.IDLE;
+    protected final ObjectMap<String, Float> cooldowns = new ObjectMap<>();
+    protected final ObjectMap<Estado, Animation<TextureRegion>> anims = new ObjectMap<>();
+    protected final Array<Texture> ownedTextures = new Array<>();
+
+    protected boolean invulnerable;
+    private float attackTimer;
+    private float stateTime;
+
+    protected Personaje(String id, String nombre, AssetManager manager, Vector2 spawn) {
+        this.id = id;
+        this.nombre = nombre;
+        this.position.set(spawn);
+        loadAnims(manager);
+    }
+
+    protected void loadAnims(AssetManager manager) {
+        anims.put(Estado.IDLE, loadAnim(manager, "idle.png", Color.GREEN));
+        anims.put(Estado.RUN, loadAnim(manager, "run.png", Color.BLUE));
+        anims.put(Estado.JUMP, loadAnim(manager, "jump.png", Color.YELLOW));
+        anims.put(Estado.FALL, loadAnim(manager, "fall.png", Color.ORANGE));
+        anims.put(Estado.ATTACK, loadAnim(manager, "attack.png", Color.RED));
+        anims.put(Estado.HURT, loadAnim(manager, "hurt.png", Color.PURPLE));
+        anims.put(Estado.DEAD, loadAnim(manager, "dead.png", Color.GRAY));
+    }
+
+    private Animation<TextureRegion> loadAnim(AssetManager manager, String file, Color color) {
+        String path = "images/personajes/animaciones/" + file;
+        Texture tex;
+        if (Gdx.files.internal(path).exists()) {
+            manager.load(path, Texture.class);
+            manager.finishLoadingAsset(path);
+            tex = manager.get(path, Texture.class);
+        } else {
+            int w = 64 * 4;
+            int h = 64;
+            com.badlogic.gdx.graphics.Pixmap pm = new com.badlogic.gdx.graphics.Pixmap(w, h, com.badlogic.gdx.graphics.Pixmap.Format.RGBA8888);
+            pm.setColor(color);
+            pm.fill();
+            tex = new Texture(pm);
+            pm.dispose();
+            ownedTextures.add(tex);
+        }
+        TextureRegion[][] tmp = TextureRegion.split(tex, tex.getWidth() / 4, tex.getHeight());
+        TextureRegion[] frames = tmp[0];
+        return new Animation<>(0.1f, frames);
+    }
+
+    public void update(float delta) {
+        handleInput(delta);
+        updateCooldowns(delta);
+        applyPhysics(delta);
+        updateEstado();
+        if (estado == Estado.ATTACK) {
+            attackTimer -= delta;
+            if (attackTimer <= 0) {
+                setEstado(onGround ? (velocity.x == 0 ? Estado.IDLE : Estado.RUN)
+                        : (velocity.y > 0 ? Estado.JUMP : Estado.FALL));
+            }
+        }
+        stateTime += delta;
+    }
+
+    protected void handleInput(float delta) {
+        // por defecto vacío
+    }
+
+    protected void updateCooldowns(float delta) {
+        for (ObjectMap.Entry<String, Float> e : cooldowns.entries()) {
+            if (e.value > 0) {
+                e.value -= delta;
+                if (e.value < 0) e.value = 0f;
+            }
+        }
+    }
+
+    protected void applyPhysics(float delta) {
+        velocity.y += Const.GRAVITY * delta;
+        if (velocity.y < Const.MAX_FALL_SPEED) {
+            velocity.y = Const.MAX_FALL_SPEED;
+        }
+        position.mulAdd(velocity, delta);
+        if (position.y <= 0) {
+            position.y = 0;
+            onGround = true;
+            velocity.y = 0;
+        } else {
+            onGround = false;
+        }
+    }
+
+    protected void updateEstado() {
+        if (estado == Estado.ATTACK || estado == Estado.HURT || estado == Estado.DEAD) {
+            return;
+        }
+        if (!onGround) {
+            setEstado(velocity.y > 0 ? Estado.JUMP : Estado.FALL);
+        } else if (velocity.x != 0) {
+            setEstado(Estado.RUN);
+        } else {
+            setEstado(Estado.IDLE);
+        }
+    }
+
+    protected void setEstado(Estado nuevo) {
+        if (estado != nuevo) {
+            estado = nuevo;
+            Gdx.app.log(nombre, "Estado: " + nuevo);
+        }
+    }
+
+    public void moveLeft() {
+        velocity.x = -speed;
+        dir = Direccion.LEFT;
+    }
+
+    public void moveRight() {
+        velocity.x = speed;
+        dir = Direccion.RIGHT;
+    }
+
+    public void stop() {
+        velocity.x = 0;
+    }
+
+    public void jump() {
+        if (onGround) {
+            velocity.y = jumpForce;
+            onGround = false;
+            setEstado(Estado.JUMP);
+        }
+    }
+
+    public void attack() {
+        if (estado != Estado.ATTACK && estado != Estado.DEAD) {
+            setEstado(Estado.ATTACK);
+            attackTimer = 0.3f;
+        }
+    }
+
+    public void takeDamage(int dmg) {
+        if (invulnerable || estado == Estado.DEAD) return;
+        hp -= dmg;
+        if (hp <= 0) {
+            hp = 0;
+            setEstado(Estado.DEAD);
+        } else {
+            setEstado(Estado.HURT);
+        }
+    }
+
+    public boolean isAlive() {
+        return hp > 0;
+    }
+
+    public void render(SpriteBatch batch) {
+        Animation<TextureRegion> anim = anims.get(estado);
+        if (anim == null) return;
+        TextureRegion frame = anim.getKeyFrame(stateTime, true);
+        boolean flip = dir == Direccion.LEFT;
+        if (frame.isFlipX() != flip) {
+            frame.flip(true, false);
+        }
+        batch.draw(frame, position.x, position.y);
+    }
+
+    public void setCooldown(String key, float cd) {
+        cooldowns.put(key, cd);
+    }
+
+    public boolean cooldownReady(String key) {
+        return !cooldowns.containsKey(key) || cooldowns.get(key) <= 0f;
+    }
+
+    public Vector2 getPosition() {
+        return position;
+    }
+
+    public void dispose() {
+        for (Texture t : ownedTextures) {
+            t.dispose();
+        }
+    }
+}

--- a/core/src/main/java/com/juegodiego/personajes/Roky.java
+++ b/core/src/main/java/com/juegodiego/personajes/Roky.java
@@ -1,0 +1,64 @@
+package com.juegodiego.personajes;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Input;
+import com.badlogic.gdx.assets.AssetManager;
+import com.badlogic.gdx.math.Vector2;
+
+/**
+ * Roky, tanque con guardia.
+ */
+public class Roky extends Personaje {
+    private boolean guarding;
+    private float guardTimer;
+
+    public Roky(AssetManager manager, Vector2 spawn) {
+        super("roky", "Roky", manager, spawn);
+        speed = 190f;
+        jumpForce = 480f;
+        attackPower = 14;
+        maxHP = hp = 140;
+    }
+
+    @Override
+    protected void handleInput(float delta) {
+        boolean left = Gdx.input.isKeyPressed(Input.Keys.A) || Gdx.input.isKeyPressed(Input.Keys.LEFT);
+        boolean right = Gdx.input.isKeyPressed(Input.Keys.D) || Gdx.input.isKeyPressed(Input.Keys.RIGHT);
+        if (left && !right) moveLeft();
+        else if (right && !left) moveRight();
+        else stop();
+        if (Gdx.input.isKeyJustPressed(Input.Keys.SPACE)) jump();
+        if (Gdx.input.isKeyJustPressed(Input.Keys.J)) attack();
+        if (Gdx.input.isKeyJustPressed(Input.Keys.K)) guard();
+    }
+
+    private void guard() {
+        if (!cooldownReady("guard")) {
+            Gdx.app.log(nombre, "Guard CD: " + cooldowns.get("guard"));
+            return;
+        }
+        setCooldown("guard", 4f);
+        guarding = true;
+        guardTimer = 1f;
+        Gdx.app.log(nombre, "Guard!");
+    }
+
+    @Override
+    public void update(float delta) {
+        super.update(delta);
+        if (guarding) {
+            guardTimer -= delta;
+            if (guardTimer <= 0) {
+                guarding = false;
+            }
+        }
+    }
+
+    @Override
+    public void takeDamage(int dmg) {
+        if (guarding) {
+            dmg *= 0.3f;
+        }
+        super.takeDamage(dmg);
+    }
+}

--- a/core/src/main/java/com/juegodiego/personajes/Thumper.java
+++ b/core/src/main/java/com/juegodiego/personajes/Thumper.java
@@ -1,0 +1,54 @@
+package com.juegodiego.personajes;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Input;
+import com.badlogic.gdx.assets.AssetManager;
+import com.badlogic.gdx.math.Vector2;
+
+/**
+ * Thumper con doble salto.
+ */
+public class Thumper extends Personaje {
+    private boolean doubleUsed;
+
+    public Thumper(AssetManager manager, Vector2 spawn) {
+        super("thumper", "Thumper", manager, spawn);
+        speed = 240f;
+        jumpForce = 520f;
+        attackPower = 12;
+        maxHP = hp = 110;
+    }
+
+    @Override
+    protected void handleInput(float delta) {
+        boolean left = Gdx.input.isKeyPressed(Input.Keys.A) || Gdx.input.isKeyPressed(Input.Keys.LEFT);
+        boolean right = Gdx.input.isKeyPressed(Input.Keys.D) || Gdx.input.isKeyPressed(Input.Keys.RIGHT);
+        if (left && !right) moveLeft();
+        else if (right && !left) moveRight();
+        else stop();
+        if (Gdx.input.isKeyJustPressed(Input.Keys.SPACE)) {
+            if (onGround) jump();
+        }
+        if (Gdx.input.isKeyJustPressed(Input.Keys.J)) attack();
+        if (Gdx.input.isKeyJustPressed(Input.Keys.K)) {
+            if (!onGround && !doubleUsed && cooldownReady("doubleJump")) {
+                doubleJump();
+            }
+        }
+    }
+
+    private void doubleJump() {
+        velocity.y = jumpForce;
+        doubleUsed = true;
+        setCooldown("doubleJump", 1.5f);
+        Gdx.app.log(nombre, "Double Jump!");
+    }
+
+    @Override
+    public void update(float delta) {
+        super.update(delta);
+        if (onGround) {
+            doubleUsed = false;
+        }
+    }
+}

--- a/core/src/main/java/com/juegodiego/screens/DemoScreen.java
+++ b/core/src/main/java/com/juegodiego/screens/DemoScreen.java
@@ -1,0 +1,110 @@
+package com.juegodiego.screens;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Input;
+import com.badlogic.gdx.Screen;
+import com.badlogic.gdx.assets.AssetManager;
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.OrthographicCamera;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
+import com.badlogic.gdx.math.Vector2;
+import com.juegodiego.Const;
+import com.juegodiego.JuegoDiegoGame;
+import com.juegodiego.personajes.Orion;
+import com.juegodiego.personajes.Personaje;
+import com.juegodiego.personajes.Roky;
+import com.juegodiego.personajes.Thumper;
+
+/**
+ * Pantalla de demostración.
+ */
+public class DemoScreen implements Screen {
+    private final JuegoDiegoGame game;
+    private final AssetManager manager;
+    private final SpriteBatch batch;
+    private final OrthographicCamera camera;
+    private final ShapeRenderer shape;
+    private Personaje personaje;
+
+    public DemoScreen(JuegoDiegoGame game) {
+        this.game = game;
+        this.manager = new AssetManager();
+        this.batch = new SpriteBatch();
+        this.shape = new ShapeRenderer();
+        this.camera = new OrthographicCamera(Const.VIEWPORT_WIDTH, Const.VIEWPORT_HEIGHT);
+        this.camera.position.set(Const.VIEWPORT_WIDTH / 2f, Const.VIEWPORT_HEIGHT / 2f, 0);
+        this.camera.update();
+        spawnOrion(new Vector2(Const.VIEWPORT_WIDTH / 2f, 0));
+    }
+
+    private void spawnOrion(Vector2 pos) {
+        disposePersonaje();
+        personaje = new Orion(manager, pos);
+    }
+
+    private void spawnRoky(Vector2 pos) {
+        disposePersonaje();
+        personaje = new Roky(manager, pos);
+    }
+
+    private void spawnThumper(Vector2 pos) {
+        disposePersonaje();
+        personaje = new Thumper(manager, pos);
+    }
+
+    private void disposePersonaje() {
+        if (personaje != null) {
+            personaje.dispose();
+        }
+    }
+
+    private void handleSpawnInput() {
+        if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_1)) {
+            spawnOrion(new Vector2(personaje != null ? personaje.getPosition().x : Const.VIEWPORT_WIDTH / 2f, 0));
+        } else if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_2)) {
+            spawnRoky(new Vector2(personaje != null ? personaje.getPosition().x : Const.VIEWPORT_WIDTH / 2f, 0));
+        } else if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_3)) {
+            spawnThumper(new Vector2(personaje != null ? personaje.getPosition().x : Const.VIEWPORT_WIDTH / 2f, 0));
+        }
+    }
+
+    @Override
+    public void render(float delta) {
+        handleSpawnInput();
+        if (personaje != null) {
+            personaje.update(delta);
+        }
+
+        Gdx.gl.glClearColor(0.1f, 0.1f, 0.1f, 1f);
+        Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+
+        camera.update();
+        batch.setProjectionMatrix(camera.combined);
+        batch.begin();
+        if (personaje != null) {
+            personaje.render(batch);
+        }
+        batch.end();
+
+        shape.setProjectionMatrix(camera.combined);
+        shape.begin(ShapeRenderer.ShapeType.Filled);
+        shape.setColor(0.2f, 0.6f, 0.2f, 1f);
+        shape.rect(0, 0, Const.VIEWPORT_WIDTH, 5);
+        shape.end();
+    }
+
+    @Override public void resize(int width, int height) {}
+    @Override public void show() {}
+    @Override public void hide() {}
+    @Override public void pause() {}
+    @Override public void resume() {}
+
+    @Override
+    public void dispose() {
+        disposePersonaje();
+        batch.dispose();
+        manager.dispose();
+        shape.dispose();
+    }
+}


### PR DESCRIPTION
## Resumen
- Añade constantes y clase principal `JuegoDiegoGame` para iniciar `DemoScreen`.
- Implementa clase abstracta `Personaje` con animaciones, física y cooldowns.
- Crea personajes jugables `Orion`, `Roky` y `Thumper` con habilidades especiales.
- Agrega `DemoScreen` que permite spawnear y controlar los personajes desde el teclado.
- Ajusta `JavaGame` como puente para el lanzador existente.

## Pruebas
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_6899404d005c83259879be1530faa6ef