### PR TITLE
Render animated sprites for characters

### DIFF
--- a/core/src/main/java/com/juegodiego/gfx/AnimationLoader.java
+++ b/core/src/main/java/com/juegodiego/gfx/AnimationLoader.java
@@ -1,0 +1,170 @@
+package com.juegodiego.gfx;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.assets.AssetManager;
+import com.badlogic.gdx.files.FileHandle;
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.Pixmap;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.Animation;
+import com.badlogic.gdx.graphics.g2d.TextureRegion;
+import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.utils.ObjectMap;
+import com.juegodiego.personajes.Personaje.Estado;
+
+import java.util.Arrays;
+import java.util.Comparator;
+
+/**
+ * Carga animaciones de sprites para personajes.
+ */
+public class AnimationLoader {
+    private static final float RUN_SPEED = 0.06f;
+    private static final float DEFAULT_SPEED = 0.1f;
+
+    public static ObjectMap<Estado, Animation<TextureRegion>> loadFor(String personajeName, AssetManager am) {
+        ObjectMap<Estado, Animation<TextureRegion>> map = new ObjectMap<>();
+        String base = "images/personajes/" + personajeName + "/";
+
+        for (Estado st : Estado.values()) {
+            String stateLower = st.name().toLowerCase();
+            FileHandle dir = Gdx.files.internal(base + stateLower);
+            if (dir.exists() && dir.isDirectory()) {
+                FileHandle[] files = dir.list("png");
+                if (files != null && files.length > 0) {
+                    Arrays.sort(files, Comparator.comparing(FileHandle::name));
+                    Array<TextureRegion> frames = new Array<>();
+                    for (FileHandle fh : files) {
+                        String path = base + stateLower + "/" + fh.name();
+                        am.load(path, Texture.class);
+                        am.finishLoadingAsset(path);
+                        Texture tex = am.get(path, Texture.class);
+                        frames.add(new TextureRegion(tex));
+                    }
+                    float fd = st == Estado.RUN ? RUN_SPEED : DEFAULT_SPEED;
+                    map.put(st, new Animation<>(fd, frames));
+                    Gdx.app.log(personajeName, st + " FOUND");
+                }
+            }
+        }
+
+        String jumpFile;
+        String deathFile;
+        String runFolder;
+        String runPrefix;
+        switch (personajeName.toLowerCase()) {
+            case "roky":
+                jumpFile = "Racoon_jump.png";
+                deathFile = "Mapache_Skin.png";
+                runFolder = "Mapache_Run";
+                runPrefix = "Mapache";
+                break;
+            case "thumper":
+                jumpFile = "Rabbit_jump.png";
+                deathFile = "Conejo_Skin.png";
+                runFolder = "Conejo_Run";
+                runPrefix = "Conejo";
+                break;
+            case "orion":
+            default:
+                jumpFile = "Cat_jump.png";
+                deathFile = "Gato_Skin.png";
+                runFolder = "Gato_Run";
+                runPrefix = "Gato";
+                break;
+        }
+        String speedBase = "images/personajes/animaciones/Speedpaws_Char/";
+
+        if (!map.containsKey(Estado.RUN)) {
+            FileHandle dir = Gdx.files.internal(speedBase + runFolder);
+            if (dir.exists()) {
+                FileHandle[] files = dir.list("png");
+                if (files != null && files.length > 0) {
+                    Arrays.sort(files, Comparator.comparing(FileHandle::name));
+                    Array<TextureRegion> frames = new Array<>();
+                    for (FileHandle fh : files) {
+                        String path = speedBase + runFolder + "/" + fh.name();
+                        am.load(path, Texture.class);
+                        am.finishLoadingAsset(path);
+                        Texture tex = am.get(path, Texture.class);
+                        frames.add(new TextureRegion(tex));
+                    }
+                    map.put(Estado.RUN, new Animation<>(RUN_SPEED, frames));
+                    Gdx.app.log(personajeName, "RUN FALLBACK");
+                }
+            }
+        }
+
+        if (!map.containsKey(Estado.IDLE) && map.containsKey(Estado.RUN)) {
+            TextureRegion first = map.get(Estado.RUN).getKeyFrames()[0];
+            map.put(Estado.IDLE, new Animation<>(DEFAULT_SPEED, first));
+            Gdx.app.log(personajeName, "IDLE FALLBACK");
+        }
+
+        if (!map.containsKey(Estado.JUMP)) {
+            String path = speedBase + "Jump_pose/" + jumpFile;
+            if (Gdx.files.internal(path).exists()) {
+                am.load(path, Texture.class);
+                am.finishLoadingAsset(path);
+                Texture tex = am.get(path, Texture.class);
+                TextureRegion region = new TextureRegion(tex);
+                map.put(Estado.JUMP, new Animation<>(DEFAULT_SPEED, region));
+                Gdx.app.log(personajeName, "JUMP FALLBACK");
+            }
+        }
+
+        if (!map.containsKey(Estado.FALL) && map.containsKey(Estado.JUMP)) {
+            map.put(Estado.FALL, map.get(Estado.JUMP));
+            Gdx.app.log(personajeName, "FALL FALLBACK");
+        }
+
+        if (!map.containsKey(Estado.ATTACK) && map.containsKey(Estado.IDLE)) {
+            map.put(Estado.ATTACK, map.get(Estado.IDLE));
+            Gdx.app.log(personajeName, "ATTACK FALLBACK");
+        }
+
+        if (!map.containsKey(Estado.HURT) && map.containsKey(Estado.IDLE)) {
+            map.put(Estado.HURT, map.get(Estado.IDLE));
+            Gdx.app.log(personajeName, "HURT FALLBACK");
+        }
+
+        if (!map.containsKey(Estado.DEAD)) {
+            String path = speedBase + "Death/" + deathFile;
+            if (Gdx.files.internal(path).exists()) {
+                am.load(path, Texture.class);
+                am.finishLoadingAsset(path);
+                Texture tex = am.get(path, Texture.class);
+                TextureRegion region = new TextureRegion(tex);
+                map.put(Estado.DEAD, new Animation<>(DEFAULT_SPEED, region));
+                Gdx.app.log(personajeName, "DEAD FALLBACK");
+            }
+        }
+
+        for (Estado st : Estado.values()) {
+            if (!map.containsKey(st)) {
+                Color color;
+                switch (st) {
+                    case RUN: color = Color.BLUE; break;
+                    case JUMP: color = Color.YELLOW; break;
+                    case FALL: color = Color.ORANGE; break;
+                    case ATTACK: color = Color.RED; break;
+                    case HURT: color = Color.PURPLE; break;
+                    case DEAD: color = Color.GRAY; break;
+                    case IDLE:
+                    default: color = Color.GREEN; break;
+                }
+                Pixmap pm = new Pixmap(32, 32, Pixmap.Format.RGBA8888);
+                pm.setColor(color);
+                pm.fill();
+                Texture tex = new Texture(pm);
+                pm.dispose();
+                TextureRegion region = new TextureRegion(tex);
+                map.put(st, new Animation<>(DEFAULT_SPEED, region));
+                Gdx.app.log(personajeName, st + " FINAL_FALLBACK");
+            }
+        }
+
+        return map;
+    }
+}
+

--- a/core/src/main/java/com/juegodiego/personajes/Orion.java
+++ b/core/src/main/java/com/juegodiego/personajes/Orion.java
@@ -4,6 +4,7 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.assets.AssetManager;
 import com.badlogic.gdx.math.Vector2;
+import com.juegodiego.gfx.AnimationLoader;
 
 /**
  * Orion, personaje ágil con dash.
@@ -14,6 +15,7 @@ public class Orion extends Personaje {
 
     public Orion(AssetManager manager, Vector2 spawn) {
         super("orion", "Orion", manager, spawn);
+        anims.putAll(AnimationLoader.loadFor("orion", manager));
         speed = 260f;
         jumpForce = 520f;
         attackPower = 10;

--- a/core/src/main/java/com/juegodiego/personajes/Roky.java
+++ b/core/src/main/java/com/juegodiego/personajes/Roky.java
@@ -4,6 +4,7 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.assets.AssetManager;
 import com.badlogic.gdx.math.Vector2;
+import com.juegodiego.gfx.AnimationLoader;
 
 /**
  * Roky, tanque con guardia.
@@ -14,6 +15,7 @@ public class Roky extends Personaje {
 
     public Roky(AssetManager manager, Vector2 spawn) {
         super("roky", "Roky", manager, spawn);
+        anims.putAll(AnimationLoader.loadFor("roky", manager));
         speed = 190f;
         jumpForce = 480f;
         attackPower = 14;

--- a/core/src/main/java/com/juegodiego/personajes/Thumper.java
+++ b/core/src/main/java/com/juegodiego/personajes/Thumper.java
@@ -4,6 +4,7 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.assets.AssetManager;
 import com.badlogic.gdx.math.Vector2;
+import com.juegodiego.gfx.AnimationLoader;
 
 /**
  * Thumper con doble salto.
@@ -13,6 +14,7 @@ public class Thumper extends Personaje {
 
     public Thumper(AssetManager manager, Vector2 spawn) {
         super("thumper", "Thumper", manager, spawn);
+        anims.putAll(AnimationLoader.loadFor("thumper", manager));
         speed = 240f;
         jumpForce = 520f;
         attackPower = 12;

--- a/core/src/main/java/com/juegodiego/screens/DemoScreen.java
+++ b/core/src/main/java/com/juegodiego/screens/DemoScreen.java
@@ -1,5 +1,18 @@
 package com.juegodiego.screens;
 
+/*
+# Desde la raíz del repo:
+# ./gradlew tasks | grep -i run
+# ./gradlew lwjgl3:run    # o desktop:run
+
+# Teclas de prueba:
+# Movimiento: A/D o ←/→
+# Salto: SPACE
+# Ataque: J
+# Habilidad: K
+# Cambiar personaje: 1 (Orion), 2 (Roky), 3 (Thumper)
+*/
+
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.Screen;
@@ -60,12 +73,18 @@ public class DemoScreen implements Screen {
     }
 
     private void handleSpawnInput() {
+        Vector2 pos = personaje != null ? new Vector2(personaje.getPosition())
+                : new Vector2(Const.VIEWPORT_WIDTH / 2f, 0);
+        Personaje.Direccion dir = personaje != null ? personaje.getDir() : Personaje.Direccion.RIGHT;
         if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_1)) {
-            spawnOrion(new Vector2(personaje != null ? personaje.getPosition().x : Const.VIEWPORT_WIDTH / 2f, 0));
+            spawnOrion(pos);
+            personaje.setDir(dir);
         } else if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_2)) {
-            spawnRoky(new Vector2(personaje != null ? personaje.getPosition().x : Const.VIEWPORT_WIDTH / 2f, 0));
+            spawnRoky(pos);
+            personaje.setDir(dir);
         } else if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_3)) {
-            spawnThumper(new Vector2(personaje != null ? personaje.getPosition().x : Const.VIEWPORT_WIDTH / 2f, 0));
+            spawnThumper(pos);
+            personaje.setDir(dir);
         }
     }
 
@@ -74,6 +93,8 @@ public class DemoScreen implements Screen {
         handleSpawnInput();
         if (personaje != null) {
             personaje.update(delta);
+            camera.position.x = personaje.getPosition().x + 32f;
+            camera.position.y = Const.VIEWPORT_HEIGHT / 2f;
         }
 
         Gdx.gl.glClearColor(0.1f, 0.1f, 0.1f, 1f);
@@ -92,6 +113,13 @@ public class DemoScreen implements Screen {
         shape.setColor(0.2f, 0.6f, 0.2f, 1f);
         shape.rect(0, 0, Const.VIEWPORT_WIDTH, 5);
         shape.end();
+
+        if (personaje != null && personaje.debugDrawHitbox) {
+            shape.begin(ShapeRenderer.ShapeType.Line);
+            shape.setColor(1f, 0f, 0f, 1f);
+            personaje.renderDebug(shape);
+            shape.end();
+        }
     }
 
     @Override public void resize(int width, int height) {}


### PR DESCRIPTION
## Summary
- load character animations with automatic fallbacks and logging
- render sprite-based characters with optional hitbox debugging
- follow the active character and allow runtime swaps in demo screen

## Testing
- `./gradlew build`
- `./gradlew tasks | grep -i run`
- `./gradlew lwjgl3:run` *(fails: GLFW_PLATFORM_UNAVAILABLE)*

------
https://chatgpt.com/codex/tasks/task_e_68994894795083259f584b9bf78049e1