### PR TITLE
Use IDLE animation when RUN frames missing

### DIFF
--- a/core/src/main/java/com/juegodiego/personajes/Orion.java
+++ b/core/src/main/java/com/juegodiego/personajes/Orion.java
@@ -17,6 +17,7 @@ public class Orion extends Personaje {
     public Orion(AssetManager manager, Vector2 spawn, GdxDiagnostics diag) {
         super("orion", "Orion", manager, spawn);
         anims.putAll(AnimationLoader.loadFor("orion", manager, diag));
+        ensureRunAnim();
         speed = 260f;
         jumpForce = 520f;
         attackPower = 10;

--- a/core/src/main/java/com/juegodiego/personajes/Personaje.java
+++ b/core/src/main/java/com/juegodiego/personajes/Personaje.java
@@ -53,6 +53,15 @@ public abstract class Personaje {
         this.position.set(spawn);
     }
 
+    protected void ensureRunAnim() {
+        Animation<TextureRegion> runAnim = anims.get(Estado.RUN);
+        Animation<TextureRegion> idleAnim = anims.get(Estado.IDLE);
+        if ((runAnim == null || runAnim.getKeyFrames().length == 0) && idleAnim != null) {
+            anims.put(Estado.RUN, idleAnim);
+            Gdx.app.log("[[RUN-FIX]]", "Assigned IDLE anim to RUN (frames=" + idleAnim.getKeyFrames().length + ")");
+        }
+    }
+
     public void update(float delta) {
         handleInput(delta);
         updateCooldowns(delta);
@@ -177,9 +186,13 @@ public abstract class Personaje {
 
     public void render(SpriteBatch batch) {
         Animation<TextureRegion> anim = anims.get(estado);
-        if (estado == Estado.RUN && (anim == null || anim.getKeyFrames().length == 0)) {
-            Gdx.app.log("[[RENDER]]", "RUN anim missing → using IDLE");
-            anim = anims.get(Estado.IDLE);
+        if (estado == Estado.RUN) {
+            Animation<TextureRegion> runAnim = anim;
+            if (runAnim == null || runAnim.getKeyFrames().length == 0) {
+                runAnim = anims.get(Estado.IDLE);
+                Gdx.app.log("[[RENDER]]", "RUN empty → drawing IDLE");
+            }
+            anim = runAnim;
         } else if (anim == null) {
             anim = anims.get(Estado.IDLE);
         }

--- a/core/src/main/java/com/juegodiego/personajes/Roky.java
+++ b/core/src/main/java/com/juegodiego/personajes/Roky.java
@@ -17,6 +17,7 @@ public class Roky extends Personaje {
     public Roky(AssetManager manager, Vector2 spawn, GdxDiagnostics diag) {
         super("roky", "Roky", manager, spawn);
         anims.putAll(AnimationLoader.loadFor("roky", manager, diag));
+        ensureRunAnim();
         speed = 190f;
         jumpForce = 480f;
         attackPower = 14;

--- a/core/src/main/java/com/juegodiego/personajes/Thumper.java
+++ b/core/src/main/java/com/juegodiego/personajes/Thumper.java
@@ -16,6 +16,7 @@ public class Thumper extends Personaje {
     public Thumper(AssetManager manager, Vector2 spawn, GdxDiagnostics diag) {
         super("thumper", "Thumper", manager, spawn);
         anims.putAll(AnimationLoader.loadFor("thumper", manager, diag));
+        ensureRunAnim();
         speed = 240f;
         jumpForce = 520f;
         attackPower = 12;


### PR DESCRIPTION
## Summary
- Reuse IDLE frames for RUN when no dedicated RUN frames are found
- Ensure characters default RUN animation to IDLE during initialization
- Render system logs and draws IDLE if RUN animation is empty

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68995b2484f083259918c23f3431c610