### PR TITLE
Ensure typed animations and safe RUN fallbacks

### DIFF
--- a/core/src/main/java/com/juegodiego/gfx/GdxDiagnostics.java
+++ b/core/src/main/java/com/juegodiego/gfx/GdxDiagnostics.java
@@ -37,11 +37,12 @@ public class GdxDiagnostics {
     public void printReport(String personaje) {
         EnumMap<Estado, AnimInfo> map = data.get(personaje);
         Gdx.app.log("[LOADER]", "=== ANIM REPORT: " + personaje + " ===");
+        Estado[] order = {Estado.IDLE, Estado.RUN, Estado.JUMP, Estado.FALL};
         if (map != null) {
-            for (Estado st : Estado.values()) {
+            for (Estado st : order) {
                 AnimInfo info = map.get(st);
                 if (info != null) {
-                    Gdx.app.log("[LOADER]", st + ": " + info.status + " (frames=" + info.frames + ") sample=" + info.sample);
+                    Gdx.app.log("[LOADER]", st + ": " + info.status + " frames=" + info.frames + " sample=" + info.sample);
                 } else {
                     Gdx.app.log("[LOADER]", st + ": <no data>");
                 }

--- a/core/src/main/java/com/juegodiego/personajes/Personaje.java
+++ b/core/src/main/java/com/juegodiego/personajes/Personaje.java
@@ -56,9 +56,13 @@ public abstract class Personaje {
     protected void ensureRunAnim() {
         Animation<TextureRegion> runAnim = anims.get(Estado.RUN);
         Animation<TextureRegion> idleAnim = anims.get(Estado.IDLE);
-        if ((runAnim == null || runAnim.getKeyFrames().length == 0) && idleAnim != null) {
-            anims.put(Estado.RUN, idleAnim);
-            Gdx.app.log("[[RUN-FIX]]", "Assigned IDLE anim to RUN (frames=" + idleAnim.getKeyFrames().length + ")");
+        if (runAnim == null || runAnim.getKeyFrames() == null || runAnim.getKeyFrames().length == 0) {
+            if (idleAnim != null && idleAnim.getKeyFrames().length > 0) {
+                Animation<TextureRegion> clone =
+                        new Animation<>(idleAnim.getFrameDuration(), idleAnim.getKeyFrames());
+                anims.put(Estado.RUN, clone);
+                Gdx.app.log("[[RUN-FIX]]", "Assigned IDLE anim to RUN (frames=" + idleAnim.getKeyFrames().length + ")");
+            }
         }
     }
 
@@ -121,7 +125,7 @@ public abstract class Personaje {
     protected void setEstado(Estado nuevo) {
         if (estado != nuevo) {
             if (nuevo == Estado.RUN) {
-                Gdx.app.log("[[STATE]]", "ENTER RUN onGround=" + onGround + " vx=" + velocity.x + " vy=" + velocity.y);
+                Gdx.app.log("[[STATE]]", "ENTER RUN onGround=" + onGround + " vx=" + velocity.x);
                 Animation<TextureRegion> runAnim = anims.get(Estado.RUN);
                 if (runAnim == null || runAnim.getKeyFrames().length == 0) {
                     Gdx.app.error("[[ERROR]]", "RUN has 0 frames after load — expected >=1");


### PR DESCRIPTION
## Summary
- Type LibGDX animation frame arrays explicitly and build animations from real `TextureRegion[]` to avoid `ClassCastException`
- Add detailed RUN loading logic with IDLE fallback and solid-color last resort
- Safeguard character initialization/rendering to reuse IDLE when RUN frames are missing and tighten state logging/reporting

## Testing
- `./gradlew build`
- `./gradlew lwjgl3:run` *(fails: GLFW_PLATFORM_UNAVAILABLE)*

------
https://chatgpt.com/codex/tasks/task_e_68995e751850832597cdaf073d3e207f