### PR TITLE
feat(escenarios): run desde raíz, assets en classpath y escenario renderizado con PNG reales

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,21 +22,6 @@ project(':core') {
     }
 }
 
-project(':lwjgl3') {
-    apply plugin: 'application'
-
-    dependencies {
-        implementation project(':core')
-        implementation "com.badlogicgames.gdx:gdx-backend-lwjgl3:$gdxVersion"
-        runtimeOnly "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-desktop"
-    }
-
-    application {
-        mainClass = 'com.juegDiego.game.lwjgl3.Lwjgl3Launcher'
-    }
-
-    sourceSets.main.resources.srcDirs += [file('../assets')]
-}
 
 wrapper {
     gradleVersion = '8.5'

--- a/core/src/main/java/com/juegDiego/core/escenarios/Escenario.java
+++ b/core/src/main/java/com/juegDiego/core/escenarios/Escenario.java
@@ -187,9 +187,10 @@ public abstract class Escenario {
             if (e.getTexture() != null) {
                 e.draw(batch);
             } else {
+                Gdx.app.log("Escenario", "WARN textura faltante para " + e.getClass().getSimpleName());
                 batch.end();
                 debugRenderer.setProjectionMatrix(batch.getProjectionMatrix());
-                debugRenderer.begin(ShapeRenderer.ShapeType.Line);
+                debugRenderer.begin(ShapeRenderer.ShapeType.Filled);
                 debugRenderer.setColor(Color.RED);
                 Rectangle b = e.getBounds();
                 debugRenderer.rect(b.x, b.y, b.width, b.height);

--- a/core/src/main/java/com/juegDiego/core/escenarios/EscenarioPrueba.java
+++ b/core/src/main/java/com/juegDiego/core/escenarios/EscenarioPrueba.java
@@ -1,8 +1,10 @@
 package com.juegDiego.core.escenarios;
 
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
 import java.io.FileNotFoundException;
 
 /**
@@ -10,29 +12,35 @@ import java.io.FileNotFoundException;
  */
 public class EscenarioPrueba extends Escenario {
     private final Texture fondo;
+    private final Texture plataformaTx;
+    private final Texture trampolinTx;
+    private final Texture obstaculoTx;
+    private final Texture cajaTx;
+    private final ShapeRenderer bgDebug = new ShapeRenderer();
 
     public EscenarioPrueba() {
-        Texture tmpFondo;
+        fondo = getTexture("images/escenarios/ecenario_Ralph/ecenario_Ralph-01.png");
+        plataformaTx = getTexture("images/escenarios/ecenario_Ralph/ecenario_Ralph-02.png");
+        trampolinTx = getTexture("images/escenarios/ecenario_Ralph/ecenario_Ralph-03.png");
+        obstaculoTx = getTexture("images/escenarios/ecenario_Ralph/ecenario_Ralph-04.png");
+        cajaTx = getTexture("images/escenarios/ecenario_Ralph/ecenario_Ralph-05.png");
         try {
             cargarDesdeJson("escenarios/prueba_1.json");
-            tmpFondo = getTexture("images/escenarios/ecenario_Ralph/ecenario_Ralph-01.png");
         } catch (FileNotFoundException e) {
             Gdx.app.log("Escenario", "JSON no encontrado, usando fallback");
             construirFallback();
             onPostCargar();
-            tmpFondo = getTexture("images/escenarios/ecenario_Ralph/ecenario_Ralph-01.png");
         }
-        fondo = tmpFondo;
     }
 
     private void construirFallback() {
-        plataformas.add(new Plataforma(0, 0, 320, 32, placeholder));
-        plataformas.add(new Plataforma(400, 120, 320, 32, placeholder));
-        plataformas.add(new Plataforma(800, 240, 320, 32, placeholder));
-        trampolines.add(new Trampolin(500, 120, 64, 32, 600f, placeholder));
-        obstaculos.add(new Obstaculo(650, 120, 32, 32, placeholder));
-        obstaculos.add(new Obstaculo(950, 240, 32, 32, placeholder));
-        cajasArmas.add(new CajaArmas(820, 280, 32, 32, placeholder));
+        plataformas.add(new Plataforma(0, 0, 320, 32, plataformaTx));
+        plataformas.add(new Plataforma(400, 120, 320, 32, plataformaTx));
+        plataformas.add(new Plataforma(800, 240, 320, 32, plataformaTx));
+        trampolines.add(new Trampolin(500, 120, 64, 16, 520f, trampolinTx));
+        obstaculos.add(new Obstaculo(650, 120, 32, 32, obstaculoTx));
+        obstaculos.add(new Obstaculo(950, 240, 32, 32, obstaculoTx));
+        cajasArmas.add(new CajaArmas(820, 280, 32, 32, cajaTx));
         clima = Clima.NEON;
     }
 
@@ -49,6 +57,15 @@ public class EscenarioPrueba extends Escenario {
     public void dibujar(SpriteBatch batch) {
         if (fondo != null) {
             batch.draw(fondo, 0, 0, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+        } else {
+            Gdx.app.log("Escenario", "WARN textura fondo faltante");
+            batch.end();
+            bgDebug.setProjectionMatrix(batch.getProjectionMatrix());
+            bgDebug.begin(ShapeRenderer.ShapeType.Filled);
+            bgDebug.setColor(Color.DARK_GRAY);
+            bgDebug.rect(0, 0, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+            bgDebug.end();
+            batch.begin();
         }
         super.dibujar(batch);
     }

--- a/core/src/main/java/com/juegDiego/game/GameScreen.java
+++ b/core/src/main/java/com/juegDiego/game/GameScreen.java
@@ -4,6 +4,7 @@ import com.badlogic.gdx.Game;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Screen;
 import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.juegDiego.core.escenarios.Escenario;
 import com.juegDiego.core.escenarios.Trampolin;
@@ -14,6 +15,7 @@ public class GameScreen implements Screen {
     private final Game game;
 
     private SpriteBatch batch;
+    private OrthographicCamera camera;
 
     private Escenario escenario;
     private Player player;
@@ -25,6 +27,9 @@ public class GameScreen implements Screen {
     @Override
     public void show() {
         batch = new SpriteBatch();
+        camera = new OrthographicCamera(Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+        camera.position.set(camera.viewportWidth / 2f, camera.viewportHeight / 2f, 0);
+        camera.update();
         escenario = Escenario.crearEscenarioPrueba();
         player = new Player(50, 200);
     }
@@ -44,6 +49,8 @@ public class GameScreen implements Screen {
             }
         }
 
+        camera.update();
+        batch.setProjectionMatrix(camera.combined);
         batch.begin();
         escenario.dibujar(batch);
         player.draw(batch);

--- a/core/src/main/java/com/juegodiego/JuegoDiegoGame.java
+++ b/core/src/main/java/com/juegodiego/JuegoDiegoGame.java
@@ -1,7 +1,8 @@
 package com.juegodiego;
 
 import com.badlogic.gdx.Game;
-import com.juegodiego.screens.DemoScreen;
+import com.badlogic.gdx.Gdx;
+import com.juegDiego.game.GameScreen;
 
 /**
  * Juego principal.
@@ -9,6 +10,9 @@ import com.juegodiego.screens.DemoScreen;
 public class JuegoDiegoGame extends Game {
     @Override
     public void create() {
-        setScreen(new DemoScreen(this));
+        Gdx.app.log("[[ASSETS]]", "user.dir=" + System.getProperty("user.dir"));
+        Gdx.app.log("[[ASSETS]]", "exists dir escenario=" + Gdx.files.internal("images/escenarios/ecenario_Ralph").exists());
+        Gdx.app.log("[[ASSETS]]", "exists fondo=" + Gdx.files.internal("images/escenarios/ecenario_Ralph/ecenario_Ralph-01.png").exists());
+        setScreen(new GameScreen(this));
     }
 }

--- a/lwjgl3/build.gradle
+++ b/lwjgl3/build.gradle
@@ -1,0 +1,22 @@
+project(':lwjgl3') {
+    apply plugin: 'application'
+
+    dependencies {
+        implementation project(':core')
+        implementation "com.badlogicgames.gdx:gdx-backend-lwjgl3:$gdxVersion"
+        runtimeOnly "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-desktop"
+    }
+
+    application {
+        mainClass = 'com.juegDiego.game.lwjgl3.Lwjgl3Launcher'
+    }
+
+    // 1) Incluir ../assets como recursos del módulo desktop
+    sourceSets.main.resources.srcDirs += [ file('../assets') ]
+
+    // 2) Forzar working dir = raíz del proyecto (donde vive /assets)
+    tasks.named('run', JavaExec) {
+        workingDir = file("${rootDir}")
+        println "[[GRADLE-RUN]] workingDir=" + workingDir
+    }
+}


### PR DESCRIPTION
## Summary
- Configure lwjgl3 module with assets on classpath and root working dir for `:lwjgl3:run`
- Log asset checks on startup and switch main game to use scenario GameScreen
- Render `EscenarioPrueba` with real PNG textures and fallback rectangles for missing assets

## Testing
- `./gradlew :lwjgl3:run` *(fails: GLFW_PLATFORM_UNAVAILABLE)*
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_689a05c908b88325b8947a658ce687f9