### PR TITLE
fix(render): viewport fijo, fondo al mundo, overlay NEON suave, texturas con filtro

### DIFF
--- a/core/src/main/java/com/juegDiego/core/escenarios/Escenario.java
+++ b/core/src/main/java/com/juegDiego/core/escenarios/Escenario.java
@@ -5,8 +5,9 @@ import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
-import com.badlogic.gdx.math.Rectangle;
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
+import com.badlogic.gdx.math.Rectangle;
+import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.JsonReader;
 import com.badlogic.gdx.utils.JsonValue;
@@ -29,12 +30,16 @@ public abstract class Escenario {
 
     private final ObjectMap<Player, Float> boostTimers = new ObjectMap<>();
     private final ObjectMap<Player, Float> baseSpeeds = new ObjectMap<>();
-    protected final Texture placeholder;
+    protected final Texture pixelBlanco;
     private final ShapeRenderer debugRenderer = new ShapeRenderer();
     private final ObjectMap<String, Texture> textures = new ObjectMap<>();
 
     public Escenario() {
-        placeholder = new Texture("images/artefactos/caja.png");
+        Pixmap pm = new Pixmap(1, 1, Pixmap.Format.RGBA8888);
+        pm.setColor(Color.WHITE);
+        pm.fill();
+        pixelBlanco = new Texture(pm);
+        pm.dispose();
     }
 
     /**
@@ -119,13 +124,6 @@ public abstract class Escenario {
         drawElements(batch, trampolines);
         drawElements(batch, obstaculos);
         drawElements(batch, cajasArmas);
-
-        if (clima == Clima.NEON) {
-            Color prev = batch.getColor();
-            batch.setColor(1f, 0f, 1f, 0.25f);
-            batch.draw(placeholder, 0, 0, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
-            batch.setColor(prev);
-        }
     }
 
     /**

--- a/core/src/main/java/com/juegDiego/core/escenarios/EscenarioPrueba.java
+++ b/core/src/main/java/com/juegDiego/core/escenarios/EscenarioPrueba.java
@@ -3,8 +3,10 @@ package com.juegDiego.core.escenarios;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.Texture.TextureFilter;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
+import com.juegDiego.game.GameScreen;
 import java.io.FileNotFoundException;
 
 /**
@@ -20,10 +22,15 @@ public class EscenarioPrueba extends Escenario {
 
     public EscenarioPrueba() {
         fondo = getTexture("images/escenarios/ecenario_Ralph/ecenario_Ralph-01.png");
+        if (fondo != null) fondo.setFilter(TextureFilter.Linear, TextureFilter.Linear);
         plataformaTx = getTexture("images/escenarios/ecenario_Ralph/ecenario_Ralph-02.png");
+        if (plataformaTx != null) plataformaTx.setFilter(TextureFilter.Linear, TextureFilter.Linear);
         trampolinTx = getTexture("images/escenarios/ecenario_Ralph/ecenario_Ralph-03.png");
+        if (trampolinTx != null) trampolinTx.setFilter(TextureFilter.Linear, TextureFilter.Linear);
         obstaculoTx = getTexture("images/escenarios/ecenario_Ralph/ecenario_Ralph-04.png");
+        if (obstaculoTx != null) obstaculoTx.setFilter(TextureFilter.Linear, TextureFilter.Linear);
         cajaTx = getTexture("images/escenarios/ecenario_Ralph/ecenario_Ralph-05.png");
+        if (cajaTx != null) cajaTx.setFilter(TextureFilter.Linear, TextureFilter.Linear);
         try {
             cargarDesdeJson("escenarios/prueba_1.json");
         } catch (FileNotFoundException e) {
@@ -37,10 +44,10 @@ public class EscenarioPrueba extends Escenario {
         plataformas.add(new Plataforma(0, 0, 320, 32, plataformaTx));
         plataformas.add(new Plataforma(400, 120, 320, 32, plataformaTx));
         plataformas.add(new Plataforma(800, 240, 320, 32, plataformaTx));
-        trampolines.add(new Trampolin(500, 120, 64, 16, 520f, trampolinTx));
-        obstaculos.add(new Obstaculo(650, 120, 32, 32, obstaculoTx));
-        obstaculos.add(new Obstaculo(950, 240, 32, 32, obstaculoTx));
-        cajasArmas.add(new CajaArmas(820, 280, 32, 32, cajaTx));
+        trampolines.add(new Trampolin(500, 120, 96, 24, 520f, trampolinTx));
+        obstaculos.add(new Obstaculo(650, 120, 64, 64, obstaculoTx));
+        obstaculos.add(new Obstaculo(950, 240, 64, 64, obstaculoTx));
+        cajasArmas.add(new CajaArmas(820, 280, 48, 48, cajaTx));
         clima = Clima.NEON;
     }
 
@@ -56,17 +63,23 @@ public class EscenarioPrueba extends Escenario {
     @Override
     public void dibujar(SpriteBatch batch) {
         if (fondo != null) {
-            batch.draw(fondo, 0, 0, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+            batch.draw(fondo, 0, 0, GameScreen.WORLD_W, GameScreen.WORLD_H);
         } else {
             Gdx.app.log("Escenario", "WARN textura fondo faltante");
             batch.end();
             bgDebug.setProjectionMatrix(batch.getProjectionMatrix());
             bgDebug.begin(ShapeRenderer.ShapeType.Filled);
             bgDebug.setColor(Color.DARK_GRAY);
-            bgDebug.rect(0, 0, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+            bgDebug.rect(0, 0, GameScreen.WORLD_W, GameScreen.WORLD_H);
             bgDebug.end();
             batch.begin();
         }
         super.dibujar(batch);
+        if (clima == Clima.NEON) {
+            Color old = batch.getColor();
+            batch.setColor(1f, 0.2f, 0.8f, 0.15f);
+            batch.draw(pixelBlanco, 0, 0, GameScreen.WORLD_W, GameScreen.WORLD_H);
+            batch.setColor(old);
+        }
     }
 }

--- a/core/src/main/java/com/juegDiego/game/GameScreen.java
+++ b/core/src/main/java/com/juegDiego/game/GameScreen.java
@@ -6,6 +6,7 @@ import com.badlogic.gdx.Screen;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.utils.viewport.FitViewport;
 import com.juegDiego.core.escenarios.Escenario;
 import com.juegDiego.core.escenarios.Trampolin;
 import com.juegDiego.core.juego.Player;
@@ -14,8 +15,12 @@ public class GameScreen implements Screen {
 
     private final Game game;
 
+    public static final float WORLD_W = 1280f;
+    public static final float WORLD_H = 720f;
+
     private SpriteBatch batch;
     private OrthographicCamera camera;
+    private FitViewport viewport;
 
     private Escenario escenario;
     private Player player;
@@ -27,9 +32,10 @@ public class GameScreen implements Screen {
     @Override
     public void show() {
         batch = new SpriteBatch();
-        camera = new OrthographicCamera(Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
-        camera.position.set(camera.viewportWidth / 2f, camera.viewportHeight / 2f, 0);
-        camera.update();
+        camera = new OrthographicCamera();
+        viewport = new FitViewport(WORLD_W, WORLD_H, camera);
+        viewport.apply();
+        camera.position.set(WORLD_W / 2f, WORLD_H / 2f, 0);
         escenario = Escenario.crearEscenarioPrueba();
         player = new Player(50, 200);
     }
@@ -59,6 +65,9 @@ public class GameScreen implements Screen {
 
     @Override
     public void resize(int width, int height) {
+        if (viewport != null) {
+            viewport.update(width, height, true);
+        }
     }
 
     @Override


### PR DESCRIPTION
## Summary
- Add fixed FitViewport and camera constants for a 1280x720 world
- Draw backgrounds to viewport size and apply linear filters to textures
- Render a soft NEON overlay using a 1x1 white pixel texture

## Testing
- `./gradlew test`
- `./gradlew :lwjgl3:run` *(fails: GLFW platform unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_689a0bf5141c8325a6fec41e91bb5e7e