### PR TITLE
feat(visual): overlay NEON suave y realce del player (resalta sin afectar escenario)

### DIFF
--- a/core/src/main/java/com/juegDiego/core/escenarios/Escenario.java
+++ b/core/src/main/java/com/juegDiego/core/escenarios/Escenario.java
@@ -171,7 +171,9 @@ public abstract class Escenario {
         if (!textures.containsKey(path)) {
             FileHandle fh = Gdx.files.internal(path);
             if (fh.exists()) {
-                textures.put(path, new Texture(fh));
+                Texture tex = new Texture(fh);
+                tex.setFilter(Texture.TextureFilter.Linear, Texture.TextureFilter.Linear);
+                textures.put(path, tex);
             } else {
                 Gdx.app.log("Escenario", "WARN textura no encontrada: " + path);
                 textures.put(path, null);

--- a/core/src/main/java/com/juegDiego/core/juego/Player.java
+++ b/core/src/main/java/com/juegDiego/core/juego/Player.java
@@ -4,6 +4,7 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.math.Rectangle;
 import com.badlogic.gdx.math.Vector2;
 
@@ -22,6 +23,7 @@ public class Player {
     public Player(float x, float y) {
         this.position.set(x, y);
         this.texture = new Texture("images/personajes/orion/placeholder.png");
+        this.texture.setFilter(Texture.TextureFilter.Linear, Texture.TextureFilter.Linear);
         updateBounds();
     }
 
@@ -53,6 +55,13 @@ public class Player {
     }
 
     public void draw(SpriteBatch batch) {
+        Color old = batch.getColor();
+        batch.setColor(0.25f, 0.10f, 0.35f, 0.6f);
+        batch.draw(texture, position.x - 1f, position.y, 64, 64);
+        batch.draw(texture, position.x + 1f, position.y, 64, 64);
+        batch.draw(texture, position.x, position.y - 1f, 64, 64);
+        batch.draw(texture, position.x, position.y + 1f, 64, 64);
+        batch.setColor(old);
         batch.draw(texture, position.x, position.y, 64, 64);
     }
 

--- a/core/src/main/java/com/juegDiego/game/GameScreen.java
+++ b/core/src/main/java/com/juegDiego/game/GameScreen.java
@@ -3,13 +3,18 @@ package com.juegDiego.game;
 import com.badlogic.gdx.Game;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Screen;
+import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.OrthographicCamera;
+import com.badlogic.gdx.graphics.Pixmap;
+import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.graphics.glutils.ShaderProgram;
 import com.badlogic.gdx.utils.viewport.FitViewport;
 import com.juegDiego.core.escenarios.Escenario;
 import com.juegDiego.core.escenarios.Trampolin;
 import com.juegDiego.core.juego.Player;
+import com.juegDiego.game.VisualConfig;
 
 public class GameScreen implements Screen {
 
@@ -25,6 +30,9 @@ public class GameScreen implements Screen {
     private Escenario escenario;
     private Player player;
 
+    private Texture overlayTexture;
+    private ShaderProgram playerShader;
+
     public GameScreen(Game game) {
         this.game = game;
     }
@@ -38,6 +46,52 @@ public class GameScreen implements Screen {
         camera.position.set(WORLD_W / 2f, WORLD_H / 2f, 0);
         escenario = Escenario.crearEscenarioPrueba();
         player = new Player(50, 200);
+
+        Pixmap pm = new Pixmap(1, 1, Pixmap.Format.RGBA8888);
+        pm.setColor(Color.WHITE);
+        pm.fill();
+        overlayTexture = new Texture(pm);
+        overlayTexture.setFilter(Texture.TextureFilter.Linear, Texture.TextureFilter.Linear);
+        pm.dispose();
+
+        if (VisualConfig.PLAYER_EFFECT_ACTIVE) {
+            ShaderProgram.pedantic = false;
+            String vert = "attribute vec4 a_position;\n" +
+                    "attribute vec4 a_color;\n" +
+                    "attribute vec2 a_texCoord0;\n" +
+                    "uniform mat4 u_projTrans;\n" +
+                    "varying vec4 v_color;\n" +
+                    "varying vec2 v_texCoords;\n" +
+                    "void main(){\n" +
+                    "   v_color = a_color;\n" +
+                    "   v_texCoords = a_texCoord0;\n" +
+                    "   gl_Position =  u_projTrans * a_position;\n" +
+                    "}";
+            String frag = "#ifdef GL_ES\n" +
+                    "precision mediump float;\n" +
+                    "#endif\n" +
+                    "varying vec4 v_color;\n" +
+                    "varying vec2 v_texCoords;\n" +
+                    "uniform sampler2D u_texture;\n" +
+                    "uniform float u_saturation;\n" +
+                    "uniform float u_contrast;\n" +
+                    "uniform float u_brightness;\n" +
+                    "void main(){\n" +
+                    "   vec4 color = texture2D(u_texture, v_texCoords) * v_color;\n" +
+                    "   float grey = dot(color.rgb, vec3(0.2126,0.7152,0.0722));\n" +
+                    "   color.rgb = mix(vec3(grey), color.rgb, u_saturation);\n" +
+                    "   color.rgb = (color.rgb - 0.5) * u_contrast + 0.5;\n" +
+                    "   color.rgb += u_brightness;\n" +
+                    "   gl_FragColor = vec4(color.rgb, color.a);\n" +
+                    "}";
+            playerShader = new ShaderProgram(vert, frag);
+            if (!playerShader.isCompiled()) {
+                Gdx.app.error("Visual", "Player shader error: " + playerShader.getLog());
+                playerShader = null;
+            }
+        }
+
+        Gdx.app.log("Visual", "overlay=" + VisualConfig.OVERLAY_COLOR + " playerFX=" + (playerShader != null));
     }
 
     @Override
@@ -59,7 +113,17 @@ public class GameScreen implements Screen {
         batch.setProjectionMatrix(camera.combined);
         batch.begin();
         escenario.dibujar(batch);
+        batch.setColor(VisualConfig.OVERLAY_COLOR);
+        batch.draw(overlayTexture, 0, 0, WORLD_W, WORLD_H);
+        batch.setColor(Color.WHITE);
+        if (playerShader != null) {
+            batch.setShader(playerShader);
+            playerShader.setUniformf("u_saturation", VisualConfig.PLAYER_SATURATION);
+            playerShader.setUniformf("u_contrast", VisualConfig.PLAYER_CONTRAST);
+            playerShader.setUniformf("u_brightness", VisualConfig.PLAYER_BRIGHTNESS);
+        }
         player.draw(batch);
+        batch.setShader(null);
         batch.end();
     }
 
@@ -85,6 +149,10 @@ public class GameScreen implements Screen {
     @Override
     public void dispose() {
         batch.dispose();
+        overlayTexture.dispose();
+        if (playerShader != null) {
+            playerShader.dispose();
+        }
     }
 }
 

--- a/core/src/main/java/com/juegDiego/game/VisualConfig.java
+++ b/core/src/main/java/com/juegDiego/game/VisualConfig.java
@@ -1,0 +1,24 @@
+package com.juegDiego.game;
+
+import com.badlogic.gdx.graphics.Color;
+
+/**
+ * Configuraci\u00f3n visual para overlays y efectos del jugador.
+ */
+public final class VisualConfig {
+    /** Color y alpha del overlay NEON sutil. */
+    public static final Color OVERLAY_COLOR = new Color(0.85f, 0.70f, 0.95f, 0.10f);
+
+    /** Activar efecto de resaltado del jugador. */
+    public static final boolean PLAYER_EFFECT_ACTIVE = true;
+
+    /**
+     * Par\u00e1metros del efecto del jugador (saturaci\u00f3n, contraste y brillo).
+     */
+    public static final float PLAYER_SATURATION = 1.35f;
+    public static final float PLAYER_CONTRAST = 1.20f;
+    public static final float PLAYER_BRIGHTNESS = 0.05f;
+
+    private VisualConfig() {
+    }
+}


### PR DESCRIPTION
## Summary
- add configurable NEON overlay and player FX parameters
- apply subtle screen overlay and player shader (saturation/contrast/brightness) with glow
- ensure linear filtering for textures

## Testing
- `./gradlew :lwjgl3:run` *(fails: GLFW_PLATFORM_UNAVAILABLE)*
- `./gradlew build -x test`


------
https://chatgpt.com/codex/tasks/task_e_689a0f90673c8325aa03df84e9c14292