### PR TITLE
Add character selection and scoring

### DIFF
--- a/core/src/main/java/com/juegDiego/core/escenarios/Escenario.java
+++ b/core/src/main/java/com/juegDiego/core/escenarios/Escenario.java
@@ -13,7 +13,7 @@ import com.badlogic.gdx.utils.JsonReader;
 import com.badlogic.gdx.utils.JsonValue;
 import com.badlogic.gdx.utils.ObjectMap;
 import com.juegDiego.core.juego.Artefacto;
-import com.juegDiego.core.juego.Player;
+import com.juegodiego.personajes.Personaje;
 
 import java.io.FileNotFoundException;
 import java.util.Random;
@@ -28,8 +28,8 @@ public abstract class Escenario {
     protected final Array<CajaArmas> cajasArmas = new Array<>();
     protected Clima clima = Clima.SOLEADO;
 
-    private final ObjectMap<Player, Float> boostTimers = new ObjectMap<>();
-    private final ObjectMap<Player, Float> baseSpeeds = new ObjectMap<>();
+    private final ObjectMap<Personaje, Float> boostTimers = new ObjectMap<>();
+    private final ObjectMap<Personaje, Float> baseSpeeds = new ObjectMap<>();
     protected final Texture pixelBlanco;
     private final ShapeRenderer debugRenderer = new ShapeRenderer();
     private final ObjectMap<String, Texture> textures = new ObjectMap<>();
@@ -99,18 +99,18 @@ public abstract class Escenario {
         for (Obstaculo o : obstaculos) o.update(delta);
         for (CajaArmas c : cajasArmas) c.update(delta);
 
-        Array<Player> toRemove = new Array<>();
-        for (ObjectMap.Entry<Player, Float> e : boostTimers) {
+        Array<Personaje> toRemove = new Array<>();
+        for (ObjectMap.Entry<Personaje, Float> e : boostTimers) {
             float time = e.value - delta;
             if (time <= 0) {
-                Player p = e.key;
+                Personaje p = e.key;
                 p.setSpeed(baseSpeeds.get(p));
                 toRemove.add(p);
             } else {
                 boostTimers.put(e.key, time);
             }
         }
-        for (Player p : toRemove) {
+        for (Personaje p : toRemove) {
             boostTimers.remove(p);
             baseSpeeds.remove(p);
         }
@@ -141,7 +141,7 @@ public abstract class Escenario {
     /**
      * Aplica un aumento temporal de velocidad al jugador.
      */
-    public void rampaVelocidad(Player player, float factor, float duracionSeg) {
+    public void rampaVelocidad(Personaje player, float factor, float duracionSeg) {
         if (!baseSpeeds.containsKey(player)) {
             baseSpeeds.put(player, player.getSpeed());
         }
@@ -157,13 +157,17 @@ public abstract class Escenario {
         return values[rng.nextInt(values.length)];
     }
 
-    public boolean intersectaPlayer(ElementoEscenario elemento, Player player) {
+    public boolean intersectaPersonaje(ElementoEscenario elemento, Personaje player) {
         return elemento.getBounds().overlaps(player.getBounds());
     }
 
     public Array<Trampolin> getTrampolines() {
         return trampolines;
     }
+
+    public Array<CajaArmas> getCajasArmas() { return cajasArmas; }
+
+    public Array<Obstaculo> getObstaculos() { return obstaculos; }
 
     protected abstract void onPostCargar();
 

--- a/core/src/main/java/com/juegDiego/game/CharacterSelectionScreen.java
+++ b/core/src/main/java/com/juegDiego/game/CharacterSelectionScreen.java
@@ -1,0 +1,86 @@
+package com.juegDiego.game;
+
+import com.badlogic.gdx.Game;
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Input;
+import com.badlogic.gdx.Screen;
+import com.badlogic.gdx.assets.AssetManager;
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.g2d.BitmapFont;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.math.Vector2;
+import com.juegodiego.gfx.GdxDiagnostics;
+import com.juegodiego.personajes.Orion;
+import com.juegodiego.personajes.Personaje;
+import com.juegodiego.personajes.Roky;
+import com.juegodiego.personajes.Thumper;
+
+/**
+ * Pantalla para seleccionar un personaje entre tres opciones.
+ */
+public class CharacterSelectionScreen implements Screen {
+    private final Game game;
+    private AssetManager manager;
+    private GdxDiagnostics diag;
+    private SpriteBatch batch;
+    private BitmapFont font;
+    private Personaje orion, roky, thumper;
+
+    public CharacterSelectionScreen(Game game) {
+        this.game = game;
+    }
+
+    @Override
+    public void show() {
+        manager = new AssetManager();
+        diag = new GdxDiagnostics();
+        batch = new SpriteBatch();
+        font = new BitmapFont();
+        orion = new Orion(manager, new Vector2(200, 0), diag);
+        roky = new Roky(manager, new Vector2(600, 0), diag);
+        thumper = new Thumper(manager, new Vector2(1000, 0), diag);
+    }
+
+    private void select(Personaje p) {
+        Gdx.app.log("Game", "Personaje seleccionado: " + p.getNombre());
+        game.setScreen(new LoadingScreen(game, p));
+    }
+
+    @Override
+    public void render(float delta) {
+        Gdx.gl.glClearColor(0, 0, 0, 1);
+        Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+
+        orion.update(delta);
+        roky.update(delta);
+        thumper.update(delta);
+
+        batch.begin();
+        font.draw(batch, "Selecciona un personaje: 1-Orion 2-Roky 3-Thumper", 20, 700);
+        orion.render(batch);
+        roky.render(batch);
+        thumper.render(batch);
+        batch.end();
+
+        if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_1)) {
+            select(orion);
+        } else if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_2)) {
+            select(roky);
+        } else if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_3)) {
+            select(thumper);
+        }
+    }
+
+    @Override public void resize(int width, int height) {}
+    @Override public void pause() {}
+    @Override public void resume() {}
+    @Override public void hide() {}
+
+    @Override
+    public void dispose() {
+        batch.dispose();
+        font.dispose();
+        // no se dispone el manager ni los personajes para reutilizarlos
+    }
+}
+

--- a/core/src/main/java/com/juegDiego/game/DefeatScreen.java
+++ b/core/src/main/java/com/juegDiego/game/DefeatScreen.java
@@ -1,0 +1,50 @@
+package com.juegDiego.game;
+
+import com.badlogic.gdx.Game;
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Screen;
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.g2d.BitmapFont;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+
+/**
+ * Pantalla mostrada al perder la partida.
+ */
+public class DefeatScreen implements Screen {
+    private final Game game;
+    private final int finalScore;
+    private SpriteBatch batch;
+    private BitmapFont font;
+
+    public DefeatScreen(Game game, int score) {
+        this.game = game;
+        this.finalScore = score;
+    }
+
+    @Override
+    public void show() {
+        batch = new SpriteBatch();
+        font = new BitmapFont();
+    }
+
+    @Override
+    public void render(float delta) {
+        Gdx.gl.glClearColor(0, 0, 0, 1);
+        Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+        batch.begin();
+        font.draw(batch, "Derrota. Puntaje: " + finalScore, 20, 400);
+        batch.end();
+    }
+
+    @Override public void resize(int width, int height) {}
+    @Override public void pause() {}
+    @Override public void resume() {}
+    @Override public void hide() {}
+
+    @Override
+    public void dispose() {
+        batch.dispose();
+        font.dispose();
+    }
+}
+

--- a/core/src/main/java/com/juegDiego/game/LoadingScreen.java
+++ b/core/src/main/java/com/juegDiego/game/LoadingScreen.java
@@ -1,0 +1,60 @@
+package com.juegDiego.game;
+
+import com.badlogic.gdx.Game;
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Screen;
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.g2d.BitmapFont;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.juegodiego.personajes.Personaje;
+
+/**
+ * Pantalla simple de carga antes de iniciar el nivel.
+ */
+public class LoadingScreen implements Screen {
+    private final Game game;
+    private final Personaje player;
+    private SpriteBatch batch;
+    private BitmapFont font;
+    private float timer;
+
+    public LoadingScreen(Game game, Personaje player) {
+        this.game = game;
+        this.player = player;
+    }
+
+    @Override
+    public void show() {
+        batch = new SpriteBatch();
+        font = new BitmapFont();
+        timer = 0f;
+        Gdx.app.log("Game", "Cargando escenario...");
+    }
+
+    @Override
+    public void render(float delta) {
+        Gdx.gl.glClearColor(0, 0, 0, 1);
+        Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+        batch.begin();
+        font.draw(batch, "Cargando...", 20, 400);
+        batch.end();
+
+        timer += delta;
+        if (timer >= 2f) {
+            Gdx.app.log("Game", "Carga completa");
+            game.setScreen(new GameScreen(game, player));
+        }
+    }
+
+    @Override public void resize(int width, int height) {}
+    @Override public void pause() {}
+    @Override public void resume() {}
+    @Override public void hide() {}
+
+    @Override
+    public void dispose() {
+        batch.dispose();
+        font.dispose();
+    }
+}
+

--- a/core/src/main/java/com/juegDiego/game/VictoryScreen.java
+++ b/core/src/main/java/com/juegDiego/game/VictoryScreen.java
@@ -1,0 +1,50 @@
+package com.juegDiego.game;
+
+import com.badlogic.gdx.Game;
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Screen;
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.g2d.BitmapFont;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+
+/**
+ * Pantalla mostrada al ganar la partida.
+ */
+public class VictoryScreen implements Screen {
+    private final Game game;
+    private final int finalScore;
+    private SpriteBatch batch;
+    private BitmapFont font;
+
+    public VictoryScreen(Game game, int score) {
+        this.game = game;
+        this.finalScore = score;
+    }
+
+    @Override
+    public void show() {
+        batch = new SpriteBatch();
+        font = new BitmapFont();
+    }
+
+    @Override
+    public void render(float delta) {
+        Gdx.gl.glClearColor(0, 0, 0, 1);
+        Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+        batch.begin();
+        font.draw(batch, "\u00A1Victoria! Puntaje: " + finalScore, 20, 400);
+        batch.end();
+    }
+
+    @Override public void resize(int width, int height) {}
+    @Override public void pause() {}
+    @Override public void resume() {}
+    @Override public void hide() {}
+
+    @Override
+    public void dispose() {
+        batch.dispose();
+        font.dispose();
+    }
+}
+

--- a/core/src/main/java/com/juegodiego/JuegoDiegoGame.java
+++ b/core/src/main/java/com/juegodiego/JuegoDiegoGame.java
@@ -2,7 +2,7 @@ package com.juegodiego;
 
 import com.badlogic.gdx.Game;
 import com.badlogic.gdx.Gdx;
-import com.juegDiego.game.GameScreen;
+import com.juegDiego.game.CharacterSelectionScreen;
 
 /**
  * Juego principal.
@@ -13,6 +13,6 @@ public class JuegoDiegoGame extends Game {
         Gdx.app.log("[[ASSETS]]", "user.dir=" + System.getProperty("user.dir"));
         Gdx.app.log("[[ASSETS]]", "exists dir escenario=" + Gdx.files.internal("images/escenarios/ecenario_Ralph").exists());
         Gdx.app.log("[[ASSETS]]", "exists fondo=" + Gdx.files.internal("images/escenarios/ecenario_Ralph/ecenario_Ralph-01.png").exists());
-        setScreen(new GameScreen(this));
+        setScreen(new CharacterSelectionScreen(this));
     }
 }

--- a/core/src/main/java/com/juegodiego/personajes/Personaje.java
+++ b/core/src/main/java/com/juegodiego/personajes/Personaje.java
@@ -6,6 +6,7 @@ import com.badlogic.gdx.graphics.g2d.Animation;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
+import com.badlogic.gdx.math.Rectangle;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.ObjectMap;
@@ -46,6 +47,8 @@ public abstract class Personaje {
     private float lastFrameW;
     private float lastFrameH;
 
+    protected final Rectangle bounds = new Rectangle();
+
     protected Personaje(String id, String nombre, AssetManager manager, Vector2 spawn) {
         this.id = id;
         this.nombre = nombre;
@@ -70,6 +73,7 @@ public abstract class Personaje {
         handleInput(delta);
         updateCooldowns(delta);
         applyPhysics(delta);
+        updateBounds();
         updateEstado();
         if (estado == Estado.ATTACK) {
             attackTimer -= delta;
@@ -107,6 +111,10 @@ public abstract class Personaje {
         } else {
             onGround = false;
         }
+    }
+
+    protected void updateBounds() {
+        bounds.set(position.x, position.y, 32, 48);
     }
 
     protected void updateEstado() {
@@ -188,6 +196,10 @@ public abstract class Personaje {
         return hp > 0;
     }
 
+    public Rectangle getBounds() {
+        return bounds;
+    }
+
     public void render(SpriteBatch batch) {
         Animation<TextureRegion> anim = anims.get(estado);
         if (estado == Estado.RUN) {
@@ -235,6 +247,10 @@ public abstract class Personaje {
         return position;
     }
 
+    public Vector2 getVelocity() {
+        return velocity;
+    }
+
     public Direccion getDir() {
         return dir;
     }
@@ -242,6 +258,12 @@ public abstract class Personaje {
     public void setDir(Direccion d) {
         this.dir = d;
     }
+
+    public float getSpeed() { return speed; }
+
+    public void setSpeed(float s) { this.speed = s; }
+
+    public String getNombre() { return nombre; }
 
     public float getLastDrawWidth() { return lastDrawW; }
     public float getLastDrawHeight() { return lastDrawH; }


### PR DESCRIPTION
## Summary
- add a character selection screen for Orion, Roky and Thumper
- insert a loading screen and victory/defeat result screens
- implement basic score with weapon pickups and damage

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_689a12da3c0c83259c250884a5d259f7