### PR TITLE
Add textual character menu and robust animation fallbacks

### DIFF
--- a/core/src/main/java/com/juegDiego/core/escenarios/EscenarioPrueba.java
+++ b/core/src/main/java/com/juegDiego/core/escenarios/EscenarioPrueba.java
@@ -21,6 +21,7 @@ public class EscenarioPrueba extends Escenario {
     private final ShapeRenderer bgDebug = new ShapeRenderer();
 
     public EscenarioPrueba() {
+        Gdx.app.log("Escenario", "Resolving background: images/escenarios/ecenario_Ralph/ecenario_Ralph-01.png");
         fondo = getTexture("images/escenarios/ecenario_Ralph/ecenario_Ralph-01.png");
         if (fondo != null) fondo.setFilter(TextureFilter.Linear, TextureFilter.Linear);
         plataformaTx = getTexture("images/escenarios/ecenario_Ralph/ecenario_Ralph-02.png");

--- a/core/src/main/java/com/juegDiego/game/CharacterSelectionScreen.java
+++ b/core/src/main/java/com/juegDiego/game/CharacterSelectionScreen.java
@@ -4,27 +4,21 @@ import com.badlogic.gdx.Game;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.Screen;
-import com.badlogic.gdx.assets.AssetManager;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
-import com.badlogic.gdx.math.Vector2;
-import com.juegodiego.gfx.GdxDiagnostics;
-import com.juegodiego.personajes.Orion;
-import com.juegodiego.personajes.Personaje;
-import com.juegodiego.personajes.Roky;
-import com.juegodiego.personajes.Thumper;
+import com.juegodiego.JuegoDiegoGame;
 
 /**
- * Pantalla para seleccionar un personaje entre tres opciones.
+ * Menú textual para elegir un personaje.
  */
 public class CharacterSelectionScreen implements Screen {
     private final Game game;
-    private AssetManager manager;
-    private GdxDiagnostics diag;
     private SpriteBatch batch;
     private BitmapFont font;
-    private Personaje orion, roky, thumper;
+    private final String[] ids = {"orion", "roky", "thumper"};
+    private final String[] names = {"ORION", "ROKY", "THUMPER"};
+    private int selected;
 
     public CharacterSelectionScreen(Game game) {
         this.game = game;
@@ -32,18 +26,22 @@ public class CharacterSelectionScreen implements Screen {
 
     @Override
     public void show() {
-        manager = new AssetManager();
-        diag = new GdxDiagnostics();
+        ((JuegoDiegoGame) game).setState(JuegoDiegoGame.State.MENU);
         batch = new SpriteBatch();
         font = new BitmapFont();
-        orion = new Orion(manager, new Vector2(200, 0), diag);
-        roky = new Roky(manager, new Vector2(600, 0), diag);
-        thumper = new Thumper(manager, new Vector2(1000, 0), diag);
+        Gdx.app.log("Game", "Menu shown");
     }
 
-    private void select(Personaje p) {
-        Gdx.app.log("Game", "Personaje seleccionado: " + p.getNombre());
-        game.setScreen(new LoadingScreen(game, p));
+    private void highlight(int idx) {
+        if (selected != idx) {
+            selected = idx;
+            Gdx.app.log("Game", "Character highlighted: " + names[selected]);
+        }
+    }
+
+    private void select() {
+        Gdx.app.log("Game", "Character selected: " + names[selected]);
+        game.setScreen(new LoadingScreen(game, ids[selected]));
     }
 
     @Override
@@ -51,36 +49,31 @@ public class CharacterSelectionScreen implements Screen {
         Gdx.gl.glClearColor(0, 0, 0, 1);
         Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
-        orion.update(delta);
-        roky.update(delta);
-        thumper.update(delta);
+        if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_1)) highlight(0);
+        if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_2)) highlight(1);
+        if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_3)) highlight(2);
+        if (Gdx.input.isKeyJustPressed(Input.Keys.ENTER)) select();
+        if (Gdx.input.isKeyJustPressed(Input.Keys.ESCAPE)) Gdx.app.exit();
 
         batch.begin();
-        font.draw(batch, "Selecciona un personaje: 1-Orion 2-Roky 3-Thumper", 20, 700);
-        orion.render(batch);
-        roky.render(batch);
-        thumper.render(batch);
-        batch.end();
-
-        if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_1)) {
-            select(orion);
-        } else if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_2)) {
-            select(roky);
-        } else if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_3)) {
-            select(thumper);
+        font.draw(batch, "SELECCIONA PERSONAJE:", 20, 440);
+        for (int i = 0; i < names.length; i++) {
+            String prefix = (i == selected ? "> " : "  ");
+            font.draw(batch, prefix + (i + 1) + ") " + names[i], 20, 400 - i * 30);
         }
+        font.draw(batch, "Pulsa 1/2/3 para elegir. Enter para confirmar. ESC para salir.", 20, 260);
+        batch.end();
     }
 
-    @Override public void resize(int width, int height) {}
-    @Override public void pause() {}
-    @Override public void resume() {}
-    @Override public void hide() {}
+    @Override public void resize(int width, int height) { }
+    @Override public void pause() { }
+    @Override public void resume() { }
+    @Override public void hide() { }
 
     @Override
     public void dispose() {
         batch.dispose();
         font.dispose();
-        // no se dispone el manager ni los personajes para reutilizarlos
     }
 }
 

--- a/core/src/main/java/com/juegDiego/game/GameScreen.java
+++ b/core/src/main/java/com/juegDiego/game/GameScreen.java
@@ -32,8 +32,8 @@ public class GameScreen implements Screen {
     private OrthographicCamera camera;
     private FitViewport viewport;
 
-    private Escenario escenario;
-    private Personaje player;
+    private final Escenario escenario;
+    private final Personaje player;
     private int score;
     private float damageCooldown;
     private final Random rng = new Random();
@@ -41,9 +41,10 @@ public class GameScreen implements Screen {
     private Texture overlayTexture;
     private ShaderProgram playerShader;
 
-    public GameScreen(Game game, Personaje player) {
+    public GameScreen(Game game, Personaje player, Escenario escenario) {
         this.game = game;
         this.player = player;
+        this.escenario = escenario;
     }
 
     @Override
@@ -53,8 +54,6 @@ public class GameScreen implements Screen {
         viewport = new FitViewport(WORLD_W, WORLD_H, camera);
         viewport.apply();
         camera.position.set(WORLD_W / 2f, WORLD_H / 2f, 0);
-        escenario = Escenario.crearEscenarioPrueba();
-        player.getPosition().set(50, 200);
 
         Pixmap pm = new Pixmap(1, 1, Pixmap.Format.RGBA8888);
         pm.setColor(Color.WHITE);
@@ -148,6 +147,8 @@ public class GameScreen implements Screen {
             return;
         }
 
+        Gdx.app.log("DEBUG", "Player state=" + player.getEstado() + " grounded=" + player.isOnGround() +
+                " pos=(" + player.getPosition().x + "," + player.getPosition().y + ")");
         camera.update();
         batch.setProjectionMatrix(camera.combined);
         batch.begin();

--- a/core/src/main/java/com/juegDiego/game/LoadingScreen.java
+++ b/core/src/main/java/com/juegDiego/game/LoadingScreen.java
@@ -6,29 +6,53 @@ import com.badlogic.gdx.Screen;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.assets.AssetManager;
+import com.badlogic.gdx.math.Vector2;
+import com.juegodiego.JuegoDiegoGame;
+import com.juegodiego.gfx.GdxDiagnostics;
+import com.juegodiego.personajes.Orion;
 import com.juegodiego.personajes.Personaje;
+import com.juegodiego.personajes.Roky;
+import com.juegodiego.personajes.Thumper;
+import com.juegDiego.core.escenarios.Escenario;
 
 /**
- * Pantalla simple de carga antes de iniciar el nivel.
+ * Pantalla de carga que prepara personaje y escenario.
  */
 public class LoadingScreen implements Screen {
     private final Game game;
-    private final Personaje player;
+    private final String characterId;
     private SpriteBatch batch;
     private BitmapFont font;
     private float timer;
+    private Personaje player;
+    private Escenario escenario;
 
-    public LoadingScreen(Game game, Personaje player) {
+    public LoadingScreen(Game game, String characterId) {
         this.game = game;
-        this.player = player;
+        this.characterId = characterId;
     }
 
     @Override
     public void show() {
+        ((JuegoDiegoGame) game).setState(JuegoDiegoGame.State.LOADING);
         batch = new SpriteBatch();
         font = new BitmapFont();
         timer = 0f;
-        Gdx.app.log("Game", "Cargando escenario...");
+        Gdx.app.log("Game", "Loading started (character=" + characterId + ", level=EscenarioPrueba)");
+
+        AssetManager manager = new AssetManager();
+        GdxDiagnostics diag = new GdxDiagnostics();
+        if ("roky".equals(characterId)) {
+            player = new Roky(manager, new Vector2(50, 200), diag);
+        } else if ("thumper".equals(characterId)) {
+            player = new Thumper(manager, new Vector2(50, 200), diag);
+        } else {
+            player = new Orion(manager, new Vector2(50, 200), diag);
+        }
+        Gdx.app.log("Game", "Character assets resolved: " + player.getNombre() + " basePath=images/personajes/" + characterId + "/");
+
+        escenario = Escenario.crearEscenarioPrueba();
     }
 
     @Override
@@ -36,20 +60,21 @@ public class LoadingScreen implements Screen {
         Gdx.gl.glClearColor(0, 0, 0, 1);
         Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
         batch.begin();
-        font.draw(batch, "Cargando...", 20, 400);
+        font.draw(batch, "CARGANDO...", 20, 400);
         batch.end();
 
         timer += delta;
         if (timer >= 2f) {
-            Gdx.app.log("Game", "Carga completa");
-            game.setScreen(new GameScreen(game, player));
+            Gdx.app.log("Game", "Loading finished");
+            ((JuegoDiegoGame) game).setState(JuegoDiegoGame.State.GAME);
+            game.setScreen(new GameScreen(game, player, escenario));
         }
     }
 
-    @Override public void resize(int width, int height) {}
-    @Override public void pause() {}
-    @Override public void resume() {}
-    @Override public void hide() {}
+    @Override public void resize(int width, int height) { }
+    @Override public void pause() { }
+    @Override public void resume() { }
+    @Override public void hide() { }
 
     @Override
     public void dispose() {

--- a/core/src/main/java/com/juegodiego/JuegoDiegoGame.java
+++ b/core/src/main/java/com/juegodiego/JuegoDiegoGame.java
@@ -8,11 +8,19 @@ import com.juegDiego.game.CharacterSelectionScreen;
  * Juego principal.
  */
 public class JuegoDiegoGame extends Game {
+    public enum State { MENU, LOADING, GAME }
+    private State state;
+
+    public void setState(State s) {
+        state = s;
+        Gdx.app.log("Game", "State -> " + s);
+    }
+
     @Override
     public void create() {
-        Gdx.app.log("[[ASSETS]]", "user.dir=" + System.getProperty("user.dir"));
-        Gdx.app.log("[[ASSETS]]", "exists dir escenario=" + Gdx.files.internal("images/escenarios/ecenario_Ralph").exists());
-        Gdx.app.log("[[ASSETS]]", "exists fondo=" + Gdx.files.internal("images/escenarios/ecenario_Ralph/ecenario_Ralph-01.png").exists());
+        Gdx.app.log("INFO", "Boot OK (LWJGL3). user.dir=" + System.getProperty("user.dir") +
+                " assetsRoot=" + Gdx.files.internal("").path());
+        setState(State.MENU);
         setScreen(new CharacterSelectionScreen(this));
     }
 }

--- a/core/src/main/java/com/juegodiego/personajes/Personaje.java
+++ b/core/src/main/java/com/juegodiego/personajes/Personaje.java
@@ -202,17 +202,21 @@ public abstract class Personaje {
 
     public void render(SpriteBatch batch) {
         Animation<TextureRegion> anim = anims.get(estado);
-        if (estado == Estado.RUN) {
-            Animation<TextureRegion> runAnim = anim;
-            if (runAnim == null || runAnim.getKeyFrames().length == 0) {
-                runAnim = anims.get(Estado.IDLE);
-                Gdx.app.log("[[RENDER]]", "RUN empty → drawing IDLE");
-            }
-            anim = runAnim;
-        } else if (anim == null) {
+        if (estado == Estado.RUN && (anim == null || anim.getKeyFrames().length == 0)) {
             anim = anims.get(Estado.IDLE);
+            if (anim != null) {
+                Gdx.app.log("WARN", "Missing frames for RUN in " + nombre + ". Using IDLE as fallback.");
+            }
+        }
+        if (anim == null || anim.getKeyFrames().length == 0) {
+            Gdx.app.log("WARN", "Attempted to draw null texture for " + estado + "/" + id + ". Skipping.");
+            return;
         }
         TextureRegion frame = anim.getKeyFrame(stateTime, true);
+        if (frame == null || frame.getTexture() == null) {
+            Gdx.app.log("WARN", "Attempted to draw null texture for " + estado + "/" + id + ". Skipping.");
+            return;
+        }
         boolean flip = dir == Direccion.LEFT;
         if (frame.isFlipX() != flip) {
             frame.flip(true, false);
@@ -264,6 +268,10 @@ public abstract class Personaje {
     public void setSpeed(float s) { this.speed = s; }
 
     public String getNombre() { return nombre; }
+
+    public String getId() { return id; }
+
+    public boolean isOnGround() { return onGround; }
 
     public float getLastDrawWidth() { return lastDrawW; }
     public float getLastDrawHeight() { return lastDrawH; }


### PR DESCRIPTION
## Summary
- replace character selection sprites with a textual menu and state machine
- add loading screen that prepares character and level, then enters game with logs
- remove green-quad animation fallbacks, using IDLE/Standing frames and warnings instead

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_689a1624e4fc8325b5116022fd1b24d0