### PR TITLE
Add image-based character menu and platform damage system

### DIFF
--- a/core/src/main/java/com/juegDiego/core/escenarios/Escenario.java
+++ b/core/src/main/java/com/juegDiego/core/escenarios/Escenario.java
@@ -165,6 +165,10 @@ public abstract class Escenario {
         return trampolines;
     }
 
+    public Array<Plataforma> getPlataformas() {
+        return plataformas;
+    }
+
     public Array<CajaArmas> getCajasArmas() { return cajasArmas; }
 
     public Array<Obstaculo> getObstaculos() { return obstaculos; }

--- a/core/src/main/java/com/juegDiego/game/CharacterSelectionScreen.java
+++ b/core/src/main/java/com/juegDiego/game/CharacterSelectionScreen.java
@@ -5,8 +5,12 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.Screen;
 import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.Pixmap;
+import com.badlogic.gdx.math.Rectangle;
 import com.juegodiego.JuegoDiegoGame;
 
 /**
@@ -16,6 +20,10 @@ public class CharacterSelectionScreen implements Screen {
     private final Game game;
     private SpriteBatch batch;
     private BitmapFont font;
+    private Texture image;
+    private Texture pixel;
+    private Rectangle[] rects = new Rectangle[3];
+    private String imageName;
     private final String[] ids = {"orion", "roky", "thumper"};
     private final String[] names = {"ORION", "ROKY", "THUMPER"};
     private int selected;
@@ -29,18 +37,34 @@ public class CharacterSelectionScreen implements Screen {
         ((JuegoDiegoGame) game).setState(JuegoDiegoGame.State.MENU);
         batch = new SpriteBatch();
         font = new BitmapFont();
-        Gdx.app.log("Game", "Menu shown");
+        String path = "images/ui/seleccion_personajes.png";
+        if (!Gdx.files.internal(path).exists()) {
+            path = "images/ui/seleccion personajes.png";
+            if (Gdx.files.internal(path).exists()) {
+                Gdx.app.log("WARN", "UI image has space in filename; consider renaming to seleccion_personajes.png");
+            }
+        }
+        image = new Texture(Gdx.files.internal(path));
+        image.setFilter(Texture.TextureFilter.Linear, Texture.TextureFilter.Linear);
+        imageName = new java.io.File(path).getName();
+        Gdx.app.log("INFO", "Selection UI image used: " + imageName);
+        Gdx.app.log("INFO", "Menu shown (image=seleccion_personajes)");
+        Pixmap pm = new Pixmap(1,1, Pixmap.Format.RGBA8888);
+        pm.setColor(Color.WHITE);
+        pm.fill();
+        pixel = new Texture(pm);
+        pm.dispose();
     }
 
     private void highlight(int idx) {
         if (selected != idx) {
             selected = idx;
-            Gdx.app.log("Game", "Character highlighted: " + names[selected]);
+            Gdx.app.log("INFO", "Character highlighted: " + names[selected]);
         }
     }
 
     private void select() {
-        Gdx.app.log("Game", "Character selected: " + names[selected]);
+        Gdx.app.log("INFO", "Character selected: " + names[selected]);
         game.setScreen(new LoadingScreen(game, ids[selected]));
     }
 
@@ -49,19 +73,49 @@ public class CharacterSelectionScreen implements Screen {
         Gdx.gl.glClearColor(0, 0, 0, 1);
         Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
+        int w = Gdx.graphics.getWidth();
+        int h = Gdx.graphics.getHeight();
+
+        float iw = image.getWidth();
+        float ih = image.getHeight();
+        float scale = Math.min(w / iw, h / ih);
+        float drawW = iw * scale;
+        float drawH = ih * scale;
+        float x = (w - drawW) / 2f;
+        float y = (h - drawH) / 2f;
+
+        float zoneW = drawW / 3f;
+        for (int i = 0; i < 3; i++) {
+            rects[i] = new Rectangle(x + i * zoneW, y, zoneW, drawH);
+        }
+
         if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_1)) highlight(0);
         if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_2)) highlight(1);
         if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_3)) highlight(2);
         if (Gdx.input.isKeyJustPressed(Input.Keys.ENTER)) select();
         if (Gdx.input.isKeyJustPressed(Input.Keys.ESCAPE)) Gdx.app.exit();
+        if (Gdx.input.justTouched()) {
+            int mx = Gdx.input.getX();
+            int my = h - Gdx.input.getY();
+            for (int i = 0; i < rects.length; i++) {
+                if (rects[i].contains(mx, my)) {
+                    highlight(i);
+                    break;
+                }
+            }
+        }
 
         batch.begin();
-        font.draw(batch, "SELECCIONA PERSONAJE:", 20, 440);
-        for (int i = 0; i < names.length; i++) {
-            String prefix = (i == selected ? "> " : "  ");
-            font.draw(batch, prefix + (i + 1) + ") " + names[i], 20, 400 - i * 30);
-        }
-        font.draw(batch, "Pulsa 1/2/3 para elegir. Enter para confirmar. ESC para salir.", 20, 260);
+        batch.draw(image, x, y, drawW, drawH);
+        Rectangle r = rects[selected];
+        batch.setColor(Color.YELLOW);
+        batch.draw(pixel, r.x, r.y, r.width, 3);
+        batch.draw(pixel, r.x, r.y + r.height - 3, r.width, 3);
+        batch.draw(pixel, r.x, r.y, 3, r.height);
+        batch.draw(pixel, r.x + r.width - 3, r.y, 3, r.height);
+        batch.setColor(Color.WHITE);
+        font.draw(batch, "Selecciona personaje: [1] ORION   [2] ROKY   [3] THUMPER", 20, 60);
+        font.draw(batch, "Pulsa 1/2/3 para elegir. ENTER para confirmar. ESC para salir.", 20, 30);
         batch.end();
     }
 
@@ -74,6 +128,8 @@ public class CharacterSelectionScreen implements Screen {
     public void dispose() {
         batch.dispose();
         font.dispose();
+        image.dispose();
+        pixel.dispose();
     }
 }
 

--- a/core/src/main/java/com/juegDiego/game/GameScreen.java
+++ b/core/src/main/java/com/juegDiego/game/GameScreen.java
@@ -11,8 +11,11 @@ import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.math.Rectangle;
+import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.utils.viewport.FitViewport;
 import com.juegDiego.core.escenarios.Escenario;
+import com.juegDiego.core.escenarios.Plataforma;
 import com.juegodiego.JuegoDiegoGame;
 import com.juegodiego.personajes.Personaje;
 
@@ -31,11 +34,16 @@ public class GameScreen implements Screen {
 
     private final Escenario escenario;
     private final Personaje player;
-    private int hp = 100;
+    private float hp = 100f;
     private int score = 0;
 
     private Texture pixel;
     private BitmapFont font;
+
+    private boolean paused;
+    private Rectangle resumeRect;
+    private Rectangle terminateRect;
+    private Rectangle quitRect;
 
     public GameScreen(Game game, Personaje player, Escenario escenario) {
         this.game = game;
@@ -64,6 +72,12 @@ public class GameScreen implements Screen {
         pm.dispose();
 
         font = new BitmapFont();
+
+        float boxW = 220f;
+        float boxH = 40f;
+        resumeRect = new Rectangle(WORLD_W / 2f - boxW / 2f, WORLD_H / 2f + 40f, boxW, boxH);
+        terminateRect = new Rectangle(WORLD_W / 2f - boxW / 2f, WORLD_H / 2f - boxH / 2f, boxW, boxH);
+        quitRect = new Rectangle(WORLD_W / 2f - boxW / 2f, WORLD_H / 2f - 40f - boxH, boxW, boxH);
     }
 
     @Override
@@ -71,24 +85,69 @@ public class GameScreen implements Screen {
         Gdx.gl.glClearColor(0, 0, 0, 1);
         Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
-        if (Gdx.input.isKeyJustPressed(Input.Keys.F)) {
-            applyDamage("sim");
-        }
-        if (Gdx.input.isKeyJustPressed(Input.Keys.G)) {
-            addScore(10, "Pickup=item");
-        }
-        if (Gdx.input.isKeyJustPressed(Input.Keys.H)) {
-            addScore(20, "Kill/Objective");
+        if (Gdx.input.isKeyJustPressed(Input.Keys.ESCAPE) && !paused) {
+            paused = true;
+            Gdx.app.log("INFO", "Pause opened");
         }
 
-        player.update(delta);
-        escenario.actualizar(delta);
+        if (!paused) {
+            if (Gdx.input.isKeyJustPressed(Input.Keys.F)) {
+                applyDamage(10f, "Damage source=sim");
+            }
+            if (Gdx.input.isKeyJustPressed(Input.Keys.G)) {
+                addScore(10, "Pickup=item");
+            }
+            if (Gdx.input.isKeyJustPressed(Input.Keys.H)) {
+                addScore(20, "Kill/Objective");
+            }
 
-        if (hp <= 0) {
-            Gdx.app.log("Game", "Player died (hp=0, score=" + score + ")");
-            ((JuegoDiegoGame) game).setState(JuegoDiegoGame.State.MENU);
-            game.setScreen(new CharacterSelectionScreen(game));
-            return;
+            player.update(delta);
+            escenario.actualizar(delta);
+
+            boolean onPlat = false;
+            Rectangle b = player.getBounds();
+            for (Plataforma p : escenario.getPlataformas()) {
+                Rectangle pb = p.getBounds();
+                if (b.overlaps(pb) && player.getVelocity().y <= 0 && b.y >= pb.y + pb.height - 10f) {
+                    player.land(pb.y + pb.height);
+                    onPlat = true;
+                    break;
+                }
+            }
+            if (!onPlat && player.isOnGround()) {
+                player.leaveGround();
+            }
+
+            if (!player.isOnGround() && !onPlat) {
+                float old = hp;
+                hp -= 10f * delta;
+                if (hp < 0f) hp = 0f;
+                if ((int)old != (int)hp) {
+                    Gdx.app.debug("Game", "HP changed: " + (int)old + " -> " + (int)hp);
+                }
+                Gdx.app.log("INFO", "Off-platform damage tick: hp=" + (int)hp);
+            }
+
+            if (player.getPosition().y < -50f) {
+                float old = hp;
+                hp -= 50f * delta;
+                if (hp < 0f) hp = 0f;
+                if ((int)old != (int)hp) {
+                    Gdx.app.debug("Game", "HP changed: " + (int)old + " -> " + (int)hp);
+                }
+                Gdx.app.log("INFO", "Out-of-world damage tick: hp=" + (int)hp);
+            }
+
+            if (hp <= 0f) {
+                Gdx.app.log("INFO", "Player died (hp=0, score=" + score + ")");
+                ((JuegoDiegoGame) game).setState(JuegoDiegoGame.State.MENU);
+                game.setScreen(new CharacterSelectionScreen(game));
+                return;
+            }
+        } else {
+            if (handlePauseInput()) {
+                return;
+            }
         }
 
         camera.update();
@@ -99,16 +158,58 @@ public class GameScreen implements Screen {
         batch.end();
 
         drawHUD();
+        if (paused) {
+            drawPauseOverlay();
+        }
     }
 
-    private void applyDamage(String source) {
-        int old = hp;
-        hp -= 10;
-        if (hp < 0) hp = 0;
-        if (hp != old) {
-            Gdx.app.debug("Game", "HP changed: " + old + " -> " + hp);
+    private boolean handlePauseInput() {
+        if (Gdx.input.isKeyJustPressed(Input.Keys.R)) {
+            paused = false;
+            Gdx.app.log("INFO", "Pause action: RESUME");
+        } else if (Gdx.input.isKeyJustPressed(Input.Keys.T)) {
+            Gdx.app.log("INFO", "Pause action: END_RUN");
+            Gdx.app.log("INFO", "Run ended by user (score=" + score + ")");
+            ((JuegoDiegoGame) game).setState(JuegoDiegoGame.State.MENU);
+            game.setScreen(new CharacterSelectionScreen(game));
+            return true;
+        } else if (Gdx.input.isKeyJustPressed(Input.Keys.Q)) {
+            Gdx.app.log("INFO", "Pause action: QUIT");
+            Gdx.app.exit();
+            return true;
         }
-        Gdx.app.log("Game", "Damage source=" + source + " hp=" + hp);
+
+        if (Gdx.input.justTouched()) {
+            Vector3 v = new Vector3(Gdx.input.getX(), Gdx.input.getY(), 0);
+            uiCamera.unproject(v);
+            float mx = v.x, my = v.y;
+            if (resumeRect.contains(mx, my)) {
+                paused = false;
+                Gdx.app.log("INFO", "Pause action: RESUME");
+            } else if (terminateRect.contains(mx, my)) {
+                Gdx.app.log("INFO", "Pause action: END_RUN");
+                Gdx.app.log("INFO", "Run ended by user (score=" + score + ")");
+                ((JuegoDiegoGame) game).setState(JuegoDiegoGame.State.MENU);
+                game.setScreen(new CharacterSelectionScreen(game));
+                return true;
+            } else if (quitRect.contains(mx, my)) {
+                Gdx.app.log("INFO", "Pause action: QUIT");
+                Gdx.app.exit();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void applyDamage(float amount, String log) {
+        float old = hp;
+        hp -= amount;
+        if (hp < 0f) hp = 0f;
+        if (hp > 100f) hp = 100f;
+        if ((int)old != (int)hp) {
+            Gdx.app.debug("Game", "HP changed: " + (int)old + " -> " + (int)hp);
+        }
+        Gdx.app.log("Game", log + " hp=" + (int)hp);
     }
 
     private void addScore(int amount, String logPrefix) {
@@ -125,7 +226,7 @@ public class GameScreen implements Screen {
         uiCamera.update();
         batch.setProjectionMatrix(uiCamera.combined);
         batch.begin();
-        font.draw(batch, "HP: " + hp, 20, WORLD_H - 20);
+        font.draw(batch, "HP: " + (int)hp, 20, WORLD_H - 20);
         float barW = 200f;
         float barH = 20f;
         batch.setColor(Color.DARK_GRAY);
@@ -134,6 +235,21 @@ public class GameScreen implements Screen {
         batch.draw(pixel, 20, WORLD_H - 40, barW * (hp / 100f), barH);
         batch.setColor(Color.WHITE);
         font.draw(batch, "Score: " + score, 20, WORLD_H - 60);
+        batch.end();
+    }
+
+    private void drawPauseOverlay() {
+        uiCamera.update();
+        batch.setProjectionMatrix(uiCamera.combined);
+        batch.begin();
+        batch.setColor(0f, 0f, 0f, 0.5f);
+        batch.draw(pixel, 0, 0, WORLD_W, WORLD_H);
+        batch.setColor(Color.WHITE);
+        font.draw(batch, "PAUSA", WORLD_W / 2f - 40f, WORLD_H / 2f + 100f);
+        font.draw(batch, "Score actual: " + score, WORLD_W / 2f - 80f, WORLD_H / 2f + 70f);
+        font.draw(batch, "[R] Reanudar", resumeRect.x + 10, resumeRect.y + 25);
+        font.draw(batch, "[T] Terminar partida y volver a Selección", terminateRect.x + 10, terminateRect.y + 25);
+        font.draw(batch, "[Q] Salir del juego", quitRect.x + 10, quitRect.y + 25);
         batch.end();
     }
 

--- a/core/src/main/java/com/juegodiego/JuegoDiegoGame.java
+++ b/core/src/main/java/com/juegodiego/JuegoDiegoGame.java
@@ -13,7 +13,7 @@ public class JuegoDiegoGame extends Game {
 
     public void setState(State s) {
         state = s;
-        Gdx.app.log("Game", "State -> " + s);
+        Gdx.app.log("INFO", "State -> " + s);
     }
 
     @Override

--- a/core/src/main/java/com/juegodiego/personajes/Personaje.java
+++ b/core/src/main/java/com/juegodiego/personajes/Personaje.java
@@ -200,6 +200,25 @@ public abstract class Personaje {
         return bounds;
     }
 
+    /**
+     * Marca al personaje como aterrizado sobre una plataforma o el suelo.
+     * Reposiciona al personaje y reinicia su velocidad vertical.
+     */
+    public void land(float y) {
+        position.y = y;
+        velocity.y = 0f;
+        onGround = true;
+        updateBounds();
+        setEstado(Math.abs(velocity.x) > 0 ? Estado.RUN : Estado.IDLE);
+    }
+
+    /**
+     * Indica que el personaje ha dejado de estar sobre una superficie.
+     */
+    public void leaveGround() {
+        onGround = false;
+    }
+
     public void render(SpriteBatch batch) {
         Animation<TextureRegion> anim = anims.get(estado);
         if (estado == Estado.RUN && (anim == null || anim.getKeyFrames().length == 0)) {


### PR DESCRIPTION
## Summary
- Add land/leaveGround helpers and expose platforms so characters collide with ground properly
- Implement image-based character selection screen with mouse/keyboard input and logs
- Apply continuous damage when off platforms, add pause overlay with resume/end/quit options, and standardize state logs

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_689a2073fba08325907caecc69ba1d62