### PR TITLE
Add basic runner race with selection and parallax

### DIFF
--- a/assets/config/race_config.json
+++ b/assets/config/race_config.json
@@ -1,0 +1,11 @@
+{
+  "finishX": 2000,
+  "npcSpeedMin": 220,
+  "npcSpeedMax": 260,
+  "obstacles": [
+    {"x":400, "width":40, "height":20},
+    {"x":800, "width":40, "height":20},
+    {"x":1200, "width":40, "height":20},
+    {"x":1600, "width":40, "height":20}
+  ]
+}

--- a/core/src/main/java/com/mygdx/runner/GameMain.java
+++ b/core/src/main/java/com/mygdx/runner/GameMain.java
@@ -1,0 +1,16 @@
+package com.mygdx.runner;
+
+import com.badlogic.gdx.Game;
+import com.badlogic.gdx.Gdx;
+import com.mygdx.runner.screens.SelectScreen;
+
+/**
+ * Entry point for the runner game. Starts at the selection screen.
+ */
+public class GameMain extends Game {
+    @Override
+    public void create() {
+        Gdx.app.log("INFO", "Boot Runner Game");
+        setScreen(new SelectScreen(this));
+    }
+}

--- a/core/src/main/java/com/mygdx/runner/characters/AiController.java
+++ b/core/src/main/java/com/mygdx/runner/characters/AiController.java
@@ -1,0 +1,43 @@
+package com.mygdx.runner.characters;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.math.MathUtils;
+import com.badlogic.gdx.math.Rectangle;
+import com.mygdx.runner.world.Track;
+
+/**
+ * Simple AI to keep a target speed and jump over obstacles.
+ */
+public class AiController {
+    private final CharacterBase character;
+    private final Track track;
+    private float targetSpeed;
+    private float noiseTimer;
+
+    public AiController(CharacterBase c, Track t, float min, float max) {
+        this.character = c;
+        this.track = t;
+        this.targetSpeed = MathUtils.random(min, max);
+        Gdx.app.log("INFO", c.getName() + " targetSpeed=" + (int)targetSpeed);
+    }
+
+    public void update(float delta) {
+        noiseTimer -= delta;
+        if (noiseTimer <= 0f) {
+            targetSpeed += MathUtils.random(-10f, 10f);
+            noiseTimer = MathUtils.random(1f, 2f);
+        }
+        float accel = 500f;
+        if (character.velocity.x < targetSpeed) character.velocity.x += accel * delta;
+        if (character.velocity.x > targetSpeed) character.velocity.x -= accel * delta;
+
+        // obstacle detection
+        for (Rectangle r : track.getObstacles()) {
+            float dx = r.x - (character.position.x + character.getWidth());
+            if (dx >= 0 && dx <= 120 && character.isOnGround()) {
+                character.jump(350f);
+                break;
+            }
+        }
+    }
+}

--- a/core/src/main/java/com/mygdx/runner/characters/CharacterBase.java
+++ b/core/src/main/java/com/mygdx/runner/characters/CharacterBase.java
@@ -1,0 +1,80 @@
+package com.mygdx.runner.characters;
+
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.math.Rectangle;
+import com.badlogic.gdx.math.Vector2;
+import com.mygdx.runner.world.Track;
+
+/**
+ * Basic character with physics and rendering as colored rectangle.
+ */
+public class CharacterBase {
+    private final String name;
+    private final Color color;
+    public final Vector2 position = new Vector2();
+    public final Vector2 velocity = new Vector2();
+    private final float width = 32f;
+    private final float height = 48f;
+    private boolean onGround = true;
+    private float jumpCooldown = 0f;
+
+    public CharacterBase(String name, Color color, float startX) {
+        this.name = name;
+        this.color = color;
+        position.set(startX, 0);
+    }
+
+    public void update(float delta, Track track) {
+        jumpCooldown -= delta;
+        // gravity
+        velocity.y -= 900f * delta;
+        // move
+        position.x += velocity.x * delta;
+        position.y += velocity.y * delta;
+        // ground
+        if (position.y <= track.getGroundY()) {
+            position.y = track.getGroundY();
+            velocity.y = 0;
+            onGround = true;
+        } else {
+            onGround = false;
+        }
+        // obstacles
+        Rectangle bounds = getBounds();
+        for (Rectangle r : track.getObstacles()) {
+            if (bounds.overlaps(r)) {
+                position.x = r.x - width;
+                bounds.x = position.x;
+                velocity.x = 0;
+            }
+        }
+        // friction
+        if (onGround) {
+            velocity.x *= 0.98f;
+        }
+    }
+
+    public void jump(float force) {
+        if (jumpCooldown <= 0f && onGround) {
+            velocity.y = force;
+            onGround = false;
+            jumpCooldown = 0.4f; // 400ms
+        }
+    }
+
+    public Rectangle getBounds() {
+        return new Rectangle(position.x, position.y, width, height);
+    }
+
+    public void render(SpriteBatch batch, com.badlogic.gdx.graphics.Texture pixel) {
+        batch.setColor(color);
+        batch.draw(pixel, position.x, position.y, width, height);
+        batch.setColor(Color.WHITE);
+    }
+
+    public String getName() { return name; }
+    public float getWidth() { return width; }
+    public float getHeight() { return height; }
+    public boolean isOnGround() { return onGround; }
+}

--- a/core/src/main/java/com/mygdx/runner/characters/PlayerController.java
+++ b/core/src/main/java/com/mygdx/runner/characters/PlayerController.java
@@ -1,0 +1,25 @@
+package com.mygdx.runner.characters;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Input;
+
+/**
+ * Handles keyboard input for the player.
+ */
+public class PlayerController {
+    private final CharacterBase character;
+    private final float accel = 600f;
+    private final float jump = 350f;
+    private final float longJump = 500f;
+
+    public PlayerController(CharacterBase c) {
+        this.character = c;
+    }
+
+    public void update(float delta) {
+        if (Gdx.input.isKeyPressed(Input.Keys.RIGHT)) character.velocity.x += accel * delta;
+        if (Gdx.input.isKeyPressed(Input.Keys.LEFT)) character.velocity.x -= accel * delta;
+        if (Gdx.input.isKeyJustPressed(Input.Keys.UP)) character.jump(jump);
+        if (Gdx.input.isKeyJustPressed(Input.Keys.SPACE)) character.jump(longJump);
+    }
+}

--- a/core/src/main/java/com/mygdx/runner/graphics/ParallaxBackground.java
+++ b/core/src/main/java/com/mygdx/runner/graphics/ParallaxBackground.java
@@ -1,0 +1,34 @@
+package com.mygdx.runner.graphics;
+
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+
+/**
+ * Very simple parallax background with colored stripes.
+ */
+public class ParallaxBackground {
+    private static class Layer {
+        Color color; float ratio; float stripe;
+        Layer(Color c, float r, float s){color=c;ratio=r;stripe=s;}
+    }
+    private final Layer[] layers;
+
+    public ParallaxBackground() {
+        layers = new Layer[]{
+                new Layer(new Color(0.3f,0.5f,0.8f,1f),0.2f,400f),
+                new Layer(new Color(0.5f,0.8f,1f,1f),0.5f,200f)
+        };
+    }
+
+    public void render(SpriteBatch batch, Texture pixel, float camX, float screenW, float screenH) {
+        for (Layer l : layers) {
+            batch.setColor(l.color);
+            float offset = (camX * l.ratio) % l.stripe;
+            for (float x = -offset; x < screenW; x += l.stripe) {
+                batch.draw(pixel, x, 0, l.stripe, screenH);
+            }
+        }
+        batch.setColor(Color.WHITE);
+    }
+}

--- a/core/src/main/java/com/mygdx/runner/screens/RaceScreen.java
+++ b/core/src/main/java/com/mygdx/runner/screens/RaceScreen.java
@@ -1,0 +1,188 @@
+package com.mygdx.runner.screens;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Input;
+import com.badlogic.gdx.Screen;
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.OrthographicCamera;
+import com.badlogic.gdx.graphics.Pixmap;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.BitmapFont;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.utils.Array;
+import com.mygdx.runner.GameMain;
+import com.mygdx.runner.characters.AiController;
+import com.mygdx.runner.characters.CharacterBase;
+import com.mygdx.runner.characters.PlayerController;
+import com.mygdx.runner.graphics.ParallaxBackground;
+import com.mygdx.runner.world.Track;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Race screen with basic physics and NPCs.
+ */
+public class RaceScreen implements Screen {
+    private final GameMain game;
+    private final String playerId;
+    private SpriteBatch batch;
+    private Texture pixel;
+    private BitmapFont font;
+    private OrthographicCamera camera;
+    private ParallaxBackground bg;
+    private Track track;
+    private CharacterBase player,npc1,npc2;
+    private PlayerController playerCtrl;
+    private AiController ai1,ai2;
+    private float countdown=3f;
+    private boolean started=false;
+    private boolean raceFinished=false;
+    private float time;
+    private Map<CharacterBase,Float> finishTimes = new HashMap<>();
+
+    public RaceScreen(GameMain game, String playerId) {
+        this.game = game;
+        this.playerId = playerId;
+    }
+
+    @Override
+    public void show() {
+        batch = new SpriteBatch();
+        font = new BitmapFont();
+        Pixmap pm = new Pixmap(1,1, Pixmap.Format.RGBA8888);
+        pm.setColor(Color.WHITE); pm.fill();
+        pixel = new Texture(pm); pm.dispose();
+        camera = new OrthographicCamera(640, 360);
+        camera.position.set(320,180,0);
+        bg = new ParallaxBackground();
+        track = new Track();
+        // create characters
+        player = new CharacterBase(playerId, colorFor(playerId), 0);
+        String[] all = {"orion","roky","thumper"};
+        java.util.List<String> npcs = new java.util.ArrayList<>();
+        for(String s: all) if(!s.equals(playerId)) npcs.add(s);
+        npc1 = new CharacterBase(npcs.get(0), colorFor(npcs.get(0)), -40);
+        npc2 = new CharacterBase(npcs.get(1), colorFor(npcs.get(1)), -80);
+        playerCtrl = new PlayerController(player);
+        ai1 = new AiController(npc1, track, track.getNpcMin(), track.getNpcMax());
+        ai2 = new AiController(npc2, track, track.getNpcMin(), track.getNpcMax());
+    }
+
+    private Color colorFor(String id){
+        if(id.equals("orion")) return Color.BLUE;
+        if(id.equals("roky")) return Color.RED;
+        if(id.equals("thumper")) return Color.GREEN;
+        return Color.WHITE;
+    }
+
+    @Override
+    public void render(float delta) {
+        Gdx.gl.glClearColor(0.1f,0.1f,0.1f,1);
+        Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+
+        if (Gdx.input.isKeyJustPressed(Input.Keys.ESCAPE)) {
+            game.setScreen(new SelectScreen(game));
+            return;
+        }
+        if (raceFinished && Gdx.input.isKeyJustPressed(Input.Keys.R)) {
+            game.setScreen(new RaceScreen(game, playerId));
+            return;
+        }
+
+        if(!started){
+            countdown -= delta;
+            if(countdown<=0){started=true;}
+        } else if(!raceFinished){
+            time += delta;
+            playerCtrl.update(delta);
+            ai1.update(delta); ai2.update(delta);
+            player.update(delta, track);
+            npc1.update(delta, track);
+            npc2.update(delta, track);
+            checkFinish(player);
+            checkFinish(npc1);
+            checkFinish(npc2);
+        }
+
+        camera.position.x = player.position.x + 150;
+        if(camera.position.x < 320) camera.position.x = 320;
+        if(camera.position.x > track.getFinishX()) camera.position.x = track.getFinishX();
+        camera.update();
+
+        batch.setProjectionMatrix(camera.combined);
+        batch.begin();
+        bg.render(batch,pixel,camera.position.x-320,640,360);
+        // ground
+        batch.setColor(Color.DARK_GRAY);
+        batch.draw(pixel, camera.position.x-320, track.getGroundY()-5, 640,5);
+        // start line
+        batch.setColor(Color.WHITE);
+        batch.draw(pixel,0,track.getGroundY(),5,50);
+        // finish line
+        batch.setColor(Color.YELLOW);
+        batch.draw(pixel,track.getFinishX(),track.getGroundY(),5,50);
+        // obstacles
+        batch.setColor(Color.BROWN);
+        for(com.badlogic.gdx.math.Rectangle r: track.getObstacles()){
+            batch.draw(pixel,r.x,r.y,r.width,r.height);
+        }
+        // characters
+        player.render(batch,pixel);
+        npc1.render(batch,pixel);
+        npc2.render(batch,pixel);
+        batch.end();
+
+        // HUD
+        batch.setProjectionMatrix(camera.combined);
+        batch.begin();
+        if(!started){
+            int count = (int)Math.ceil(countdown);
+            String msg = count>0?String.valueOf(count):"GO!";
+            font.draw(batch,msg,camera.position.x-10,camera.position.y+100);
+        }
+        Array<CharacterBase> arr = new Array<>();
+        arr.add(player); arr.add(npc1); arr.add(npc2);
+        arr.sort((a,b)->Float.compare(b.position.x,a.position.x));
+        float y = camera.position.y+160;
+        for(int i=0;i<arr.size;i++){
+            font.draw(batch,(i+1)+") "+arr.get(i).getName(),camera.position.x-300,y); y-=20;}
+        if(raceFinished){
+            font.draw(batch,"Ganador: "+winnerName(),camera.position.x-80,camera.position.y+40);
+            font.draw(batch,"R para reiniciar, ESC para menu",camera.position.x-120,camera.position.y+20);
+        }
+        batch.end();
+    }
+
+    private void checkFinish(CharacterBase c){
+        if(!finishTimes.containsKey(c) && c.position.x >= track.getFinishX()){
+            finishTimes.put(c,time);
+            Gdx.app.log("INFO","Finish "+c.getName()+" t="+String.format("%.2f",time));
+            if(finishTimes.size()==3){
+                raceFinished=true;
+                java.util.List<Map.Entry<CharacterBase,Float>> list = new java.util.ArrayList<>(finishTimes.entrySet());
+                list.sort(java.util.Comparator.comparing(Map.Entry::getValue));
+                StringBuilder sb = new StringBuilder("Order: ");
+                for(int i=0;i<list.size();i++){
+                    sb.append((i+1)).append(")").append(list.get(i).getKey().getName()).append(" ");
+                }
+                Gdx.app.log("INFO",sb.toString());
+            }
+        }
+    }
+
+    private String winnerName(){
+        CharacterBase win = null; float best=Float.MAX_VALUE;
+        for(Map.Entry<CharacterBase,Float> e: finishTimes.entrySet()){
+            if(e.getValue()<best){best=e.getValue();win=e.getKey();}
+        }
+        return win!=null?win.getName():"";
+    }
+
+    @Override public void resize(int width,int height){}
+    @Override public void pause(){}
+    @Override public void resume(){}
+    @Override public void hide(){}
+    @Override public void dispose(){batch.dispose();pixel.dispose();font.dispose();}
+}

--- a/core/src/main/java/com/mygdx/runner/screens/SelectScreen.java
+++ b/core/src/main/java/com/mygdx/runner/screens/SelectScreen.java
@@ -1,0 +1,87 @@
+package com.mygdx.runner.screens;
+
+import com.badlogic.gdx.Game;
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Input;
+import com.badlogic.gdx.Screen;
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.Pixmap;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.BitmapFont;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.mygdx.runner.GameMain;
+
+/**
+ * Simple text based character selection screen.
+ */
+public class SelectScreen implements Screen {
+    private final Game game;
+    private SpriteBatch batch;
+    private BitmapFont font;
+    private Texture pixel;
+    private int selected;
+    private final String[] ids = {"orion", "roky", "thumper"};
+    private final String[] names = {"ORION", "ROKY", "THUMPER"};
+
+    public SelectScreen(Game game) {
+        this.game = game;
+    }
+
+    @Override
+    public void show() {
+        batch = new SpriteBatch();
+        font = new BitmapFont();
+        Pixmap pm = new Pixmap(1,1, Pixmap.Format.RGBA8888);
+        pm.setColor(Color.WHITE);
+        pm.fill();
+        pixel = new Texture(pm);
+        pm.dispose();
+        selected = 0;
+    }
+
+    @Override
+    public void render(float delta) {
+        Gdx.gl.glClearColor(0,0,0,1);
+        Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+
+        if (Gdx.input.isKeyJustPressed(Input.Keys.DOWN)) selected = (selected + 1) % ids.length;
+        if (Gdx.input.isKeyJustPressed(Input.Keys.UP)) selected = (selected - 1 + ids.length) % ids.length;
+        if (Gdx.input.isKeyJustPressed(Input.Keys.ENTER)) {
+            Gdx.app.log("INFO", "Character selected: " + ids[selected]);
+            game.setScreen(new RaceScreen((GameMain)game, ids[selected]));
+        }
+        if (Gdx.input.isKeyJustPressed(Input.Keys.ESCAPE)) {
+            Gdx.app.exit();
+        }
+
+        batch.begin();
+        for (int i=0;i<ids.length;i++) {
+            String label = names[i];
+            float x = 100;
+            float y = 300 - i*30;
+            if (i==selected) {
+                font.setColor(Color.YELLOW);
+                batch.draw(pixel, x-20, y-20, 200, 25);
+            } else {
+                font.setColor(Color.WHITE);
+            }
+            font.draw(batch, label, x, y);
+        }
+        font.setColor(Color.WHITE);
+        font.draw(batch, "UP/DOWN select, ENTER confirm", 50, 50);
+        batch.end();
+    }
+
+    @Override public void resize(int width, int height) {}
+    @Override public void pause() {}
+    @Override public void resume() {}
+    @Override public void hide() {}
+
+    @Override
+    public void dispose() {
+        batch.dispose();
+        font.dispose();
+        pixel.dispose();
+    }
+}

--- a/core/src/main/java/com/mygdx/runner/world/Track.java
+++ b/core/src/main/java/com/mygdx/runner/world/Track.java
@@ -1,0 +1,55 @@
+package com.mygdx.runner.world;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.files.FileHandle;
+import com.badlogic.gdx.math.Rectangle;
+import com.badlogic.gdx.utils.Json;
+import com.badlogic.gdx.utils.JsonValue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Defines start/finish and obstacles.
+ */
+public class Track {
+    private float startX = 0f;
+    private float finishX = 3000f;
+    private final List<Rectangle> obstacles = new ArrayList<>();
+    private float groundY = 0f;
+    private float npcMin = 220f;
+    private float npcMax = 260f;
+
+    public Track() {
+        loadConfig();
+    }
+
+    private void loadConfig() {
+        try {
+            FileHandle fh = Gdx.files.internal("config/race_config.json");
+            if (!fh.exists()) return;
+            Json json = new Json();
+            JsonValue root = json.fromJson(null, fh);
+            finishX = root.getFloat("finishX", finishX);
+            npcMin = root.getFloat("npcSpeedMin", npcMin);
+            npcMax = root.getFloat("npcSpeedMax", npcMax);
+            JsonValue obs = root.get("obstacles");
+            if (obs != null) {
+                for (JsonValue o : obs) {
+                    float x = o.getFloat("x");
+                    float w = o.getFloat("width");
+                    float h = o.getFloat("height");
+                    obstacles.add(new Rectangle(x, groundY, w, h));
+                }
+            }
+        } catch (Exception e) {
+            Gdx.app.error("Track", "Failed to load config", e);
+        }
+    }
+
+    public float getFinishX() { return finishX; }
+    public List<Rectangle> getObstacles() { return obstacles; }
+    public float getNpcMin() { return npcMin; }
+    public float getNpcMax() { return npcMax; }
+    public float getGroundY() { return groundY; }
+}

--- a/lwjgl3/src/main/java/com/juegDiego/game/lwjgl3/Lwjgl3Launcher.java
+++ b/lwjgl3/src/main/java/com/juegDiego/game/lwjgl3/Lwjgl3Launcher.java
@@ -2,13 +2,13 @@ package com.juegDiego.game.lwjgl3;
 
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application;
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration;
-import com.juegDiego.game.JavaGame;
+import com.mygdx.runner.GameMain;
 
 public class Lwjgl3Launcher {
     public static void main(String[] args) {
         Lwjgl3ApplicationConfiguration config = new Lwjgl3ApplicationConfiguration();
         config.setTitle("JavaGame");
         config.setWindowedMode(640, 480);
-        new Lwjgl3Application(new JavaGame(), config);
+        new Lwjgl3Application(new GameMain(), config);
     }
 }


### PR DESCRIPTION
## Summary
- add GameMain entry and simple character selection screen
- implement race screen with parallax background, NPC AI, and restart logic
- include configurable track with obstacles and NPC speed ranges

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_689a5fd9a5c08325a41df27e23b05fd8