### PR TITLE
Add selection menu art, speed tuning, and infinite parallax

### DIFF
--- a/core/src/main/java/com/mygdx/runner/characters/AiController.java
+++ b/core/src/main/java/com/mygdx/runner/characters/AiController.java
@@ -13,18 +13,23 @@ public class AiController {
     private final Track track;
     private float targetSpeed;
     private float noiseTimer;
+    private final float minSpeed;
+    private final float maxSpeed;
 
     public AiController(CharacterBase c, Track t, float min, float max) {
         this.character = c;
         this.track = t;
+        this.minSpeed = min;
+        this.maxSpeed = max;
         this.targetSpeed = MathUtils.random(min, max);
-        Gdx.app.log("INFO", c.getName() + " targetSpeed=" + (int)targetSpeed);
+        Gdx.app.log("INFO", "NPC[target=" + (int)targetSpeed + "]");
     }
 
     public void update(float delta) {
         noiseTimer -= delta;
         if (noiseTimer <= 0f) {
             targetSpeed += MathUtils.random(-10f, 10f);
+            targetSpeed = MathUtils.clamp(targetSpeed, minSpeed, maxSpeed);
             noiseTimer = MathUtils.random(1f, 2f);
         }
         float accel = 500f;

--- a/core/src/main/java/com/mygdx/runner/characters/CharacterBase.java
+++ b/core/src/main/java/com/mygdx/runner/characters/CharacterBase.java
@@ -4,6 +4,7 @@ import com.badlogic.gdx.graphics.g2d.Animation;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.math.Rectangle;
 import com.badlogic.gdx.math.Vector2;
 import com.mygdx.runner.graphics.AnimationLoader;
@@ -27,9 +28,18 @@ public class CharacterBase {
     private final EnumMap<State, Animation<TextureRegion>> anims;
     private final com.badlogic.gdx.utils.Array<Texture> textures;
 
+    private final float maxSpeedX;
+    private final float frictionX;
+
     public CharacterBase(String name, float startX) {
+        this(name, startX, 250f, 6f);
+    }
+
+    public CharacterBase(String name, float startX, float maxSpeedX, float frictionX) {
         this.name = name;
         position.set(startX, 0);
+        this.maxSpeedX = maxSpeedX;
+        this.frictionX = frictionX;
         AnimationLoader.Result res = AnimationLoader.load(name);
         this.anims = res.animations;
         this.textures = res.textures;
@@ -62,8 +72,11 @@ public class CharacterBase {
         }
         // friction
         if (onGround) {
-            velocity.x *= 0.98f;
+            float drag = frictionX * delta;
+            velocity.x -= velocity.x * drag;
         }
+        // clamp horizontal speed
+        velocity.x = MathUtils.clamp(velocity.x, -maxSpeedX, maxSpeedX);
         if (velocity.x > 0) facingRight = true;
         else if (velocity.x < 0) facingRight = false;
     }
@@ -104,4 +117,5 @@ public class CharacterBase {
     public float getWidth() { return width; }
     public float getHeight() { return height; }
     public boolean isOnGround() { return onGround; }
+    public float getMaxSpeedX() { return maxSpeedX; }
 }

--- a/core/src/main/java/com/mygdx/runner/characters/PlayerController.java
+++ b/core/src/main/java/com/mygdx/runner/characters/PlayerController.java
@@ -2,13 +2,14 @@ package com.mygdx.runner.characters;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
+import com.badlogic.gdx.math.MathUtils;
 
 /**
  * Handles keyboard input for the player.
  */
 public class PlayerController {
     private final CharacterBase character;
-    private final float accel = 600f;
+    private final float accel = 800f;
     private final float jump = 350f;
     private final float longJump = 500f;
 
@@ -19,6 +20,7 @@ public class PlayerController {
     public void update(float delta) {
         if (Gdx.input.isKeyPressed(Input.Keys.RIGHT)) character.velocity.x += accel * delta;
         if (Gdx.input.isKeyPressed(Input.Keys.LEFT)) character.velocity.x -= accel * delta;
+        character.velocity.x = MathUtils.clamp(character.velocity.x, -character.getMaxSpeedX(), character.getMaxSpeedX());
         if (Gdx.input.isKeyJustPressed(Input.Keys.UP)) character.jump(jump);
         if (Gdx.input.isKeyJustPressed(Input.Keys.SPACE)) character.jump(longJump);
     }

--- a/core/src/main/java/com/mygdx/runner/graphics/ParallaxBackground.java
+++ b/core/src/main/java/com/mygdx/runner/graphics/ParallaxBackground.java
@@ -28,6 +28,7 @@ public class ParallaxBackground {
             dir = Gdx.files.internal(base);
             Gdx.app.log("INFO", "Escenario fallback: " + base);
         }
+        Gdx.app.log("INFO", "ParallaxBackground: capas desde " + base);
         FileHandle[] files = dir.list();
         Array<FileHandle> pngs = new Array<>();
         for (FileHandle f : files) {
@@ -60,7 +61,9 @@ public class ParallaxBackground {
             float scale = screenH / height;
             float drawW = width * scale;
             float offset = (camX * l.ratio) % drawW;
-            for (float x = -offset; x < screenW; x += drawW) {
+            if (offset < 0) offset += drawW;
+            float start = -offset;
+            for (float x = start; x < screenW + drawW; x += drawW) {
                 batch.draw(l.region, x, 0, drawW, screenH);
             }
         }

--- a/core/src/main/java/com/mygdx/runner/screens/RaceScreen.java
+++ b/core/src/main/java/com/mygdx/runner/screens/RaceScreen.java
@@ -59,15 +59,16 @@ public class RaceScreen implements Screen {
         bg = new ParallaxBackground();
         track = new Track();
         // create characters
-        player = new CharacterBase(playerId, 0);
+        player = new CharacterBase(playerId, 0, 200f, 6f);
         String[] all = {"orion","roky","thumper"};
         java.util.List<String> npcs = new java.util.ArrayList<>();
         for(String s: all) if(!s.equals(playerId)) npcs.add(s);
-        npc1 = new CharacterBase(npcs.get(0), -40);
-        npc2 = new CharacterBase(npcs.get(1), -80);
+        npc1 = new CharacterBase(npcs.get(0), -40, 210f, 6f);
+        npc2 = new CharacterBase(npcs.get(1), -80, 210f, 6f);
         playerCtrl = new PlayerController(player);
         ai1 = new AiController(npc1, track, track.getNpcMin(), track.getNpcMax());
         ai2 = new AiController(npc2, track, track.getNpcMin(), track.getNpcMax());
+        Gdx.app.log("INFO", "Player maxSpeedX=200 accelX=800 frictionX=6");
     }
 
     @Override
@@ -100,16 +101,17 @@ public class RaceScreen implements Screen {
         }
 
         camera.position.x = player.position.x + 150;
-        if(camera.position.x < 320) camera.position.x = 320;
+        float halfW = camera.viewportWidth / 2f;
+        if(camera.position.x < halfW) camera.position.x = halfW;
         if(camera.position.x > track.getFinishX()) camera.position.x = track.getFinishX();
         camera.update();
 
         batch.setProjectionMatrix(camera.combined);
         batch.begin();
-        bg.render(batch,camera.position.x-320,640,360);
+        bg.render(batch,camera.position.x - halfW, camera.viewportWidth, camera.viewportHeight);
         // ground
         batch.setColor(Color.DARK_GRAY);
-        batch.draw(pixel, camera.position.x-320, track.getGroundY()-5, 640,5);
+        batch.draw(pixel, camera.position.x - halfW, track.getGroundY()-5, camera.viewportWidth,5);
         // start line
         batch.setColor(Color.WHITE);
         batch.draw(pixel,0,track.getGroundY(),5,50);
@@ -173,7 +175,12 @@ public class RaceScreen implements Screen {
         return win!=null?win.getName():"";
     }
 
-    @Override public void resize(int width,int height){}
+    @Override public void resize(int width,int height){
+        camera.viewportWidth = width;
+        camera.viewportHeight = height;
+        camera.position.set(width/2f, height/2f, 0);
+        camera.update();
+    }
     @Override public void pause(){}
     @Override public void resume(){}
     @Override public void hide(){}

--- a/core/src/main/java/com/mygdx/runner/screens/SelectScreen.java
+++ b/core/src/main/java/com/mygdx/runner/screens/SelectScreen.java
@@ -4,13 +4,24 @@ import com.badlogic.gdx.Game;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.Screen;
+import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.Animation;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.graphics.g2d.TextureRegion;
+import com.badlogic.gdx.utils.viewport.FitViewport;
+import com.badlogic.gdx.utils.viewport.Viewport;
 import com.mygdx.runner.GameMain;
+import com.mygdx.runner.graphics.AnimationLoader;
+import com.mygdx.runner.characters.State;
+
+import java.util.Arrays;
+import java.util.Comparator;
 
 /**
  * Simple text based character selection screen.
@@ -20,6 +31,11 @@ public class SelectScreen implements Screen {
     private SpriteBatch batch;
     private BitmapFont font;
     private Texture pixel;
+    private Texture uiBg;
+    private TextureRegion preview;
+    private AnimationLoader.Result previewData;
+    private OrthographicCamera camera;
+    private Viewport viewport;
     private int selected;
     private final String[] ids = {"orion", "roky", "thumper"};
     private final String[] names = {"ORION", "ROKY", "THUMPER"};
@@ -37,7 +53,14 @@ public class SelectScreen implements Screen {
         pm.fill();
         pixel = new Texture(pm);
         pm.dispose();
+        camera = new OrthographicCamera();
+        viewport = new FitViewport(640,360,camera);
+        viewport.apply();
+        camera.position.set(320,180,0);
+        camera.update();
         selected = 0;
+        loadUiBg();
+        updatePreview();
     }
 
     @Override
@@ -45,8 +68,8 @@ public class SelectScreen implements Screen {
         Gdx.gl.glClearColor(0,0,0,1);
         Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
-        if (Gdx.input.isKeyJustPressed(Input.Keys.DOWN)) selected = (selected + 1) % ids.length;
-        if (Gdx.input.isKeyJustPressed(Input.Keys.UP)) selected = (selected - 1 + ids.length) % ids.length;
+        if (Gdx.input.isKeyJustPressed(Input.Keys.DOWN)) { selected = (selected + 1) % ids.length; updatePreview(); }
+        if (Gdx.input.isKeyJustPressed(Input.Keys.UP)) { selected = (selected - 1 + ids.length) % ids.length; updatePreview(); }
         if (Gdx.input.isKeyJustPressed(Input.Keys.ENTER)) {
             Gdx.app.log("INFO", "Character selected: " + ids[selected]);
             game.setScreen(new RaceScreen((GameMain)game, ids[selected]));
@@ -55,7 +78,11 @@ public class SelectScreen implements Screen {
             Gdx.app.exit();
         }
 
+        batch.setProjectionMatrix(camera.combined);
         batch.begin();
+        if (uiBg != null) {
+            batch.draw(uiBg, 0, 0, viewport.getWorldWidth(), viewport.getWorldHeight());
+        }
         for (int i=0;i<ids.length;i++) {
             String label = names[i];
             float x = 100;
@@ -68,12 +95,15 @@ public class SelectScreen implements Screen {
             }
             font.draw(batch, label, x, y);
         }
+        if (preview != null) {
+            batch.draw(preview, 400, 120, 128, 128);
+        }
         font.setColor(Color.WHITE);
         font.draw(batch, "UP/DOWN select, ENTER confirm", 50, 50);
         batch.end();
     }
 
-    @Override public void resize(int width, int height) {}
+    @Override public void resize(int width, int height) { viewport.update(width,height,true); }
     @Override public void pause() {}
     @Override public void resume() {}
     @Override public void hide() {}
@@ -83,5 +113,52 @@ public class SelectScreen implements Screen {
         batch.dispose();
         font.dispose();
         pixel.dispose();
+        if (uiBg != null) uiBg.dispose();
+        if (previewData != null) {
+            for (Texture t : previewData.textures) t.dispose();
+        }
+    }
+
+    private void loadUiBg() {
+        FileHandle fh = Gdx.files.internal("assets/images/ui/seleccion_personajes.png");
+        if (!fh.exists()) fh = Gdx.files.internal("assets/ui/seleccion_personajes.png");
+        if (fh.exists()) {
+            uiBg = new Texture(fh);
+            uiBg.setFilter(Texture.TextureFilter.Linear, Texture.TextureFilter.Linear);
+            Gdx.app.log("INFO", "SelectScreen: fondo UI cargado OK");
+        } else {
+            Gdx.app.log("WARN", "SelectScreen: fondo UI no encontrado");
+        }
+    }
+
+    private String firstFramePath(String id, String state) {
+        String dirPath = "assets/images/personajes/" + id + "/" + state;
+        FileHandle dir = Gdx.files.internal(dirPath);
+        if (dir.exists() && dir.isDirectory()) {
+            FileHandle[] files = dir.list("png");
+            Arrays.sort(files, Comparator.comparing(FileHandle::name));
+            if (files.length > 0) return files[0].path();
+        }
+        return null;
+    }
+
+    private void updatePreview() {
+        if (previewData != null) {
+            for (Texture t : previewData.textures) t.dispose();
+        }
+        String id = ids[selected];
+        previewData = AnimationLoader.load(id);
+        Animation<TextureRegion> anim = previewData.animations.get(State.IDLE);
+        String path = firstFramePath(id, "idle");
+        if (anim == null || path == null) {
+            anim = previewData.animations.get(State.RUN);
+            path = firstFramePath(id, "run");
+        }
+        if (anim == null || path == null) {
+            path = "assets/images/personajes/" + id + "/placeholder.png";
+            anim = previewData.animations.get(State.IDLE);
+        }
+        preview = anim != null ? anim.getKeyFrames()[0] : null;
+        Gdx.app.log("INFO", "SelectScreen preview: " + path);
     }
 }

--- a/core/src/main/java/com/mygdx/runner/world/Track.java
+++ b/core/src/main/java/com/mygdx/runner/world/Track.java
@@ -17,8 +17,8 @@ public class Track {
     private float finishX = 3000f;
     private final List<Rectangle> obstacles = new ArrayList<>();
     private float groundY = 0f;
-    private float npcMin = 220f;
-    private float npcMax = 260f;
+    private float npcMin = 160f;
+    private float npcMax = 210f;
 
     public Track() {
         loadConfig();


### PR DESCRIPTION
## Summary
- Enhance character selection screen with background image, preview sprites, and safe asset fallbacks.
- Tune player and NPC movement speeds, applying clamped velocities and smoother drag.
- Rework parallax background to tile infinitely without gaps and log loaded layers.

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_689a663c88e883259c206ccd2fe67039