### PR TITLE
Fix character preview asset path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.gradle/
+**/build/

--- a/core/src/main/java/com/mygdx/runner/screens/SelectScreen.java
+++ b/core/src/main/java/com/mygdx/runner/screens/SelectScreen.java
@@ -133,7 +133,7 @@ public class SelectScreen implements Screen {
             preview = cache.get(id);
             pendingId = null;
         } else {
-            String path = "assets/images/personajes/" + id + "/idle/1.png";
+            String path = "assets/images/personajes/" + id + "/placeholder.png";
             if (!gm.getAssetManager().isLoaded(path, Texture.class)) {
                 gm.getAssetManager().load(path, Texture.class);
             }
@@ -147,7 +147,7 @@ public class SelectScreen implements Screen {
         if (pendingId == null) return;
         GameMain gm = (GameMain) game;
         if (gm.getAssetManager().update()) {
-            String path = "assets/images/personajes/" + pendingId + "/idle/1.png";
+            String path = "assets/images/personajes/" + pendingId + "/placeholder.png";
             if (gm.getAssetManager().isLoaded(path)) {
                 Texture tex = gm.getAssetManager().get(path, Texture.class);
                 tex.setFilter(Texture.TextureFilter.Linear, Texture.TextureFilter.Linear);


### PR DESCRIPTION
## Summary
- avoid crashes when entering the character selection screen by loading placeholder textures instead of missing idle frames
- ignore Gradle build directories

## Testing
- `./gradlew test`
- `./gradlew lwjgl3:run` *(fails: GLFW_PLATFORM_UNAVAILABLE)*

------
https://chatgpt.com/codex/tasks/task_e_689a6ffd711c8325b099e0cac0c84559