### PR TITLE
Handle missing character frames in race loader

### DIFF
--- a/core/src/main/java/com/mygdx/runner/screens/loading/RaceLoadingScreen.java
+++ b/core/src/main/java/com/mygdx/runner/screens/loading/RaceLoadingScreen.java
@@ -43,10 +43,19 @@ public class RaceLoadingScreen implements Screen {
         String[] all={"orion","roky","thumper"};
         for(String id: all){
             String base="assets/images/personajes/"+id+"/";
+            // ensure placeholder is available for CharacterBase
+            String placeholder = base + "placeholder.png";
+            if (Gdx.files.internal(placeholder).exists() && !am.isLoaded(placeholder)) {
+                am.load(placeholder, Texture.class, param);
+            }
+            // attempt to preload a representative frame for common states
             String[] states={"idle","run","jump","fall"};
             for(String st:states){
                 String path=base+st+"/1.png";
-                if(!am.isLoaded(path)) am.load(path, Texture.class, param);
+                // only queue existing files to avoid runtime errors
+                if(Gdx.files.internal(path).exists() && !am.isLoaded(path)) {
+                    am.load(path, Texture.class, param);
+                }
             }
         }
         // scenario layers


### PR DESCRIPTION
## Summary
- Avoid preloading nonexistent character frame files
- Load placeholder textures for characters when real frames are missing

## Testing
- `./gradlew test`
- `./gradlew -q lwjgl3:run` *(fails: GLFW_PLATFORM_UNAVAILABLE)*

------
https://chatgpt.com/codex/tasks/task_e_689a715a56788325988c83e577d286ad